### PR TITLE
Use DataFrame.reset_index() to simplify render_table method while also…

### DIFF
--- a/cauldron/render/__init__.py
+++ b/cauldron/render/__init__.py
@@ -282,25 +282,17 @@ def table(
         random.randint(0, 1e8)
     )
 
-    column_headers = data_frame.columns.tolist()
-    if include_index:
-        column_headers.insert(0, 'index')
-    column_headers = ['"{}"'.format(x) for x in column_headers]
-
-    data = []
-
     df_source = (
         data_frame.head(max_rows)
         if len(data_frame) > max_rows else
         data_frame
     )
 
-    for index, row in df_source.iterrows():
-        entry = row.tolist()
-        if include_index:
-            entry.insert(0, index)
-        data.append(entry)
+    if include_index:
+        df_source = df_source.reset_index()
 
+    column_headers = ['"{}"'.format(x) for x in df_source.columns.tolist()]
+    data = df_source.values.tolist()
     json_data = json_internal.dumps(data, cls=encoding.ComplexJsonEncoder)
 
     return templating.render_template(


### PR DESCRIPTION
…providing support for MultiIndex dataframes. This resolves #15

Not sure about the tests though. I didn't contribute any tests to verify my changes. However, the existing tests still pass and you don't have any tests checking for the actual rendering output anyway