### PR TITLE
PyTest Support

### DIFF
--- a/cauldron/runner/__init__.py
+++ b/cauldron/runner/__init__.py
@@ -83,16 +83,17 @@ def close():
     return True
 
 
-def reload_libraries():
+def reload_libraries(library_directories: list = None):
     """
     Reload the libraries stored in the project's local and shared library
     directories
-
-    :return:
     """
-
+    directories = library_directories or []
     project = cauldron.project.internal_project
-    if not project:
+    if project:
+        directories += project.library_directories
+
+    if not directories:
         return
 
     def reload_module(path: str, library_directory: str):
@@ -120,7 +121,7 @@ def reload_libraries():
 
     return [
         reloaded_module
-        for directory in project.library_directories
+        for directory in directories
         for reloaded_module in reload_library(directory)
         if reload_module is not None
     ]

--- a/cauldron/settings.json
+++ b/cauldron/settings.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.3",
+  "version": "0.3.4",
   "notebookVersion": "v1"
 }

--- a/cauldron/steptest/__init__.py
+++ b/cauldron/steptest/__init__.py
@@ -6,7 +6,7 @@ import unittest
 from cauldron import environ
 from cauldron import runner
 from cauldron.cli import commander
-from cauldron.session import exposed
+from cauldron.session import exposed  # noqa
 from cauldron.steptest import support
 from cauldron.steptest.functional import CauldronTest
 from cauldron.steptest.results import StepTestRunResult
@@ -24,6 +24,10 @@ class StepTestCase(unittest.TestCase):
     """
 
     def __init__(self, *args, **kwargs):
+        """
+        Initializes a StepTestCase with default attribute values that will be
+        populated during the setup and teardown phases of each test.
+        """
         super(StepTestCase, self).__init__(*args, **kwargs)
         self.results_directory = None
         self.temp_directories = dict()
@@ -66,7 +70,9 @@ class StepTestCase(unittest.TestCase):
 
     def open_project(self) -> 'exposed.ExposedProject':
         """
-        Returns the Response object populated by the open project command
+        Opens the project associated with this test and returns the public
+        (exposed) project after it has been loaded. If the project cannot be
+        opened the test will fail.
         """
         try:
             project_path = self.make_project_path()
@@ -100,6 +106,12 @@ class StepTestCase(unittest.TestCase):
             self.fail('{}'.format(error))
 
     def tearDown(self):
+        """
+        After a test is run this function is used to undo any side effects that
+        were created by setting up and running the test. This includes removing
+        the temporary directories that were created to store test information
+        during test execution.
+        """
         super(StepTestCase, self).tearDown()
 
         # Close any open project so that it doesn't persist to the next test
@@ -118,8 +130,16 @@ class StepTestCase(unittest.TestCase):
 
     def make_temp_path(self, identifier, *args) -> str:
         """
+        Creates a temporary path within a named directory created
+        for the test being executed. If any directories in the path don't exist
+        already, they will be created before returning the path.
+
         :param identifier:
+            The identifier for the test the is used to name the folder in which
+            the temp path will reside within the root test folder for the given
+            test.
         :param args:
-        :return:
+            Any additional path elements to identify the path that will
+            appear beneath the identifier folder.
         """
         return support.make_temp_path(self.temp_directories, identifier, *args)

--- a/cauldron/steptest/functional.py
+++ b/cauldron/steptest/functional.py
@@ -6,7 +6,7 @@ import tempfile
 from cauldron import environ
 from cauldron import runner
 from cauldron.cli import commander
-from cauldron.session import exposed
+from cauldron.session import exposed  # noqa
 from cauldron.steptest import support
 from cauldron.steptest.results import StepTestRunResult
 
@@ -128,7 +128,7 @@ class CauldronTest:
         environ.systems.remove(self.results_directory)
         self.results_directory = None
 
-        for key, path in self.temp_directories.items():
+        for path in self.temp_directories.values():
             environ.systems.remove(path)
 
         paths_to_remove = [p for p in self._library_paths if p in sys.path]

--- a/cauldron/steptest/functional.py
+++ b/cauldron/steptest/functional.py
@@ -1,41 +1,49 @@
 import inspect
 import os
+import sys
 import tempfile
-import unittest
 
 from cauldron import environ
 from cauldron import runner
 from cauldron.cli import commander
 from cauldron.session import exposed
 from cauldron.steptest import support
-from cauldron.steptest.functional import CauldronTest
 from cauldron.steptest.results import StepTestRunResult
-from cauldron.steptest.support import find_project_directory
 
 
-class StepTestCase(unittest.TestCase):
-    """
-    The base class to use for step "unit" testing. This class overrides
-    the default setup and tearDown methods from the unittest.TestCase to add
-    functionality for loading and unloading the Cauldron notebook settings
-    needed to run and test steps. If you override either of these methods
-    make sure that you call their super methods as well or the functionality
-    will be lost.
-    """
+class CauldronTest:
+    """..."""
 
     def __init__(self, *args, **kwargs):
-        super(StepTestCase, self).__init__(*args, **kwargs)
+        """..."""
+        self._call_args = args
+        self._call_kwargs = kwargs
+        self._test_function = None
         self.results_directory = None
         self.temp_directories = dict()
 
-    def setUp(self):
-        """
-        A modified setup function that handles opening the project for testing.
-        If you override the setUp function in your tests, be sure to call the
-        super function so that this initialization happens properly
-        """
+    def __call__(self, test_function):
+        """..."""
+        self._test_function = test_function
+
+        def cauldron_test_wrapper(*args, **kwargs):
+            return self.run_test(*args, **kwargs)
+
+        project_path = self.make_project_path('cauldron.json')
+        self._library_paths = support.get_library_paths(project_path)
+        sys.path.extend(self._library_paths)
+
+        # Load libraries before calling test functions so that patching works
+        # correctly, but do this during the decoration process so subsequent
+        # patching isn't reverted.
+        runner.reload_libraries(self._library_paths)
+
+        cauldron_test_wrapper.__name__ = test_function.__name__
+        return cauldron_test_wrapper
+
+    def setup(self):
+        """..."""
         environ.modes.add(environ.modes.TESTING)
-        super(StepTestCase, self).setUp()
         results_directory = tempfile.mkdtemp(
             prefix='cd-step-test-results-{}--'.format(self.__class__.__name__)
         )
@@ -43,10 +51,6 @@ class StepTestCase(unittest.TestCase):
         environ.configs.put(results_directory=results_directory, persists=False)
         self.temp_directories = dict()
         self.open_project()
-
-        # Load libraries before calling test functions so that patching works
-        # correctly.
-        runner.reload_libraries()
 
     def make_project_path(self, *args) -> str:
         """
@@ -60,7 +64,7 @@ class StepTestCase(unittest.TestCase):
             components are specified, the location returned will be the
             project directory itself.
         """
-        filename = inspect.getfile(self.__class__)
+        filename = inspect.getfile(self._test_function)
         project_directory = support.find_project_directory(filename)
         return os.path.join(project_directory, *args)
 
@@ -72,10 +76,11 @@ class StepTestCase(unittest.TestCase):
             project_path = self.make_project_path()
             return support.open_project(project_path)
         except RuntimeError as error:
-            self.fail('{}'.format(error))
+            raise AssertionError('{}'.format(error))
 
+    @classmethod
     def run_step(
-            self,
+            cls,
             step_name: str,
             allow_failure: bool = False
     ) -> StepTestRunResult:
@@ -94,13 +99,25 @@ class StepTestCase(unittest.TestCase):
             A StepTestRunResult instance containing information about the
             execution of the step.
         """
-        try:
-            return support.run_step(step_name, allow_failure)
-        except AssertionError as error:
-            self.fail('{}'.format(error))
+        return support.run_step(step_name, allow_failure)
 
-    def tearDown(self):
-        super(StepTestCase, self).tearDown()
+    def make_temp_path(self, identifier, *args) -> str:
+        """
+        :param identifier:
+        :param args:
+        :return:
+        """
+        return support.make_temp_path(self.temp_directories, identifier, *args)
+
+    def run_test(self, *args, **kwargs):
+        """..."""
+        self.setup()
+        result = self._test_function(self, *args, **kwargs)
+        self.tear_down()
+        return result
+
+    def tear_down(self):
+        """..."""
 
         # Close any open project so that it doesn't persist to the next test
         closed = commander.execute('close', '')
@@ -114,12 +131,8 @@ class StepTestCase(unittest.TestCase):
         for key, path in self.temp_directories.items():
             environ.systems.remove(path)
 
-        environ.modes.remove(environ.modes.TESTING)
+        paths_to_remove = [p for p in self._library_paths if p in sys.path]
+        for path in paths_to_remove:
+            sys.path.remove(path)
 
-    def make_temp_path(self, identifier, *args) -> str:
-        """
-        :param identifier:
-        :param args:
-        :return:
-        """
-        return support.make_temp_path(self.temp_directories, identifier, *args)
+        environ.modes.remove(environ.modes.TESTING)

--- a/cauldron/steptest/results.py
+++ b/cauldron/steptest/results.py
@@ -1,0 +1,52 @@
+from cauldron import environ
+from cauldron.session import projects
+from cauldron.session.caching import SharedCache
+
+
+class StepTestRunResult:
+    """
+    This class contains information returned from running a step during testing.
+    """
+
+    def __init__(
+            self,
+            step: 'projects.ProjectStep',
+            response: 'environ.Response'
+    ):
+        self._step = step  # type: projects.ProjectStep
+        self._response = response  # type: environ.Response
+        self._locals = SharedCache().put(**step.test_locals)
+
+    @property
+    def local(self) -> SharedCache:
+        """
+        Container object that holds all of the local variables that were
+        defined within the run step
+        """
+
+        return self._locals
+
+    @property
+    def success(self) -> bool:
+        """
+        Whether or not the step was successfully run. This value will be
+        False if there as an uncaught exception during the execution of the
+        step.
+        """
+
+        return not self._response.failed
+
+    def echo_error(self) -> str:
+        """
+        Creates a string representation of the exception that cause the step
+        to fail if an exception occurred. Otherwise, an empty string is returned.
+
+        :return:
+            The string representation of the exception that caused the running
+            step to fail or a blank string if no exception occurred
+        """
+
+        if not self._response.errors:
+            return ''
+
+        return '{}'.format(self._response.errors[0].serialize())

--- a/cauldron/steptest/support.py
+++ b/cauldron/steptest/support.py
@@ -1,0 +1,148 @@
+import json
+import os
+import tempfile
+import time
+import typing
+
+import cauldron as cd
+from cauldron import environ
+from cauldron.cli import commander
+from cauldron.session import exposed
+from cauldron.steptest.results import StepTestRunResult
+
+
+def find_project_directory(subdirectory: str) -> typing.Union[str, None]:
+    """
+    Finds the root project directory from a subdirectory within the project
+    folder.
+
+    :param subdirectory:
+        The subdirectory to use to search for the project directory. The
+        subdirectory may also be the project directory.
+    :return:
+        The project directory that contains the specified subdirectory or None
+        if no project directory was found.
+    """
+    if os.path.exists(os.path.join(subdirectory, 'cauldron.json')):
+        return subdirectory
+
+    parent = os.path.dirname(subdirectory)
+    if parent == subdirectory:
+        raise FileNotFoundError('Unable to find a Cauldron project directory.')
+
+    if os.path.exists(os.path.join(parent, 'cauldron.json')):
+        return parent
+
+    return find_project_directory(parent)
+
+
+def open_project(project_path: str) -> 'exposed.ExposedProject':
+    """
+    Returns the Response object populated by the open project command
+    """
+    res = commander.execute(
+        name='open',
+        raw_args='{} --forget'.format(project_path),
+        response=environ.Response()
+    )
+    res.thread.join()
+
+    # Prevent threading race conditions
+    check_count = 0
+    while res.success and not cd.project.internal_project:
+        if check_count > 100:
+            break
+
+        check_count += 1
+        time.sleep(0.25)
+
+    if res.failed or not cd.project.internal_project:
+        raise RuntimeError(
+            'Unable to open project at path "{}"'.format(project_path)
+        )
+
+    os.chdir(cd.project.internal_project.source_directory)
+
+    return cd.project
+
+
+def run_step(
+        step_name: str,
+        allow_failure: bool = False
+) -> StepTestRunResult:
+    """
+    Runs the specified step by name its complete filename including extension
+
+    :param step_name:
+        The full filename of the step to be run including its extension.
+    :param allow_failure:
+        Whether or not to allow a failed result to be returned. If False,
+        a failed attempt to run a step will cause the current test to
+        fail immediately before returning a value from this function call.
+        Override this with a True value to have the step failure data
+        passed back for inspection.
+    :return:
+        A StepTestRunResult instance containing information about the
+        execution of the step.
+    """
+    project = cd.project.internal_project
+    if not project:
+        raise AssertionError(
+            'No project was open. Unable to run step "{}"'
+            .format(step_name)
+        )
+
+    step = project.get_step(step_name)
+    if not step:
+        raise AssertionError('No step named "{}" was found'.format(step_name))
+
+    response = commander.execute('run', '"{}" --force'.format(step_name))
+    response.thread.join()
+
+    if not allow_failure and response.failed:
+        raise AssertionError('Failed to run step "{}"'.format(step_name))
+
+    return StepTestRunResult(step, response)
+
+
+def make_temp_path(existing_directories, identifier, *args) -> str:
+    """
+    :param existing_directories:
+    :param identifier:
+    :param args:
+    :return:
+    """
+    if identifier not in existing_directories:
+        existing_directories[identifier] = tempfile.mkdtemp(
+            prefix='cd-step-test-{}'.format(identifier)
+        )
+    return os.path.realpath(
+        os.path.join(existing_directories[identifier], *args)
+    )
+
+
+def get_library_paths(project_path: str):
+    """..."""
+    path = (
+        os.path.join(project_path, 'cauldron.json')
+        if not project_path.endswith('cauldron.json') else
+        project_path
+    )
+    directory = os.path.dirname(path)
+
+    with open(path, 'r') as f:
+        settings = json.load(f)
+
+    def listify(value):
+        return [value] if isinstance(value, str) else list(value)
+
+    folders = listify(settings.get('library_folders') or ['libs'])
+
+    # Include the remote shared library folder as well
+    folders.append('../__cauldron_shared_libs')
+
+    results = [
+        environ.paths.clean(os.path.join(directory, folder))
+        for folder in folders
+    ]
+    return [r for r in results if os.path.exists(r) and os.path.isdir(r)]

--- a/cauldron/steptest/support.py
+++ b/cauldron/steptest/support.py
@@ -38,7 +38,14 @@ def find_project_directory(subdirectory: str) -> typing.Union[str, None]:
 
 def open_project(project_path: str) -> 'exposed.ExposedProject':
     """
-    Returns the Response object populated by the open project command
+    Opens the project located at the specified path and returns the public
+    (exposed) project after it has been loaded. If the project cannot be
+    opened a `RuntimeError` will be raised instead.
+
+    :param project_path:
+        The path to the Cauldron project to open. It should be either a
+        directory that contains a `cauldron.json` file or a file path to the
+        `cauldron.json` file for the project to load.
     """
     res = commander.execute(
         name='open',
@@ -105,12 +112,24 @@ def run_step(
     return StepTestRunResult(step, response)
 
 
-def make_temp_path(existing_directories, identifier, *args) -> str:
+def make_temp_path(existing_directories: dict, identifier: str, *args) -> str:
     """
+    Creates a temporary path within a named directory created
+    for the test being executed. If any directories in the path don't exist
+    already, they will be created before returning the path.
+
     :param existing_directories:
+        A dictionary that contains a map of existing temporary directory paths
+        listed by their identifiers. Used to determine what exists and what
+        needs to be added. If the folder for the given identifier does not
+        exist yet, it will be added to this dictionary (mutating the results).
     :param identifier:
+        The identifier for the test the is used to name the folder in which
+        the temp path will reside within the root test folder for the given
+        test.
     :param args:
-    :return:
+        Any additional path elements to identify the path that will
+        appear beneath the identifier folder.
     """
     if identifier not in existing_directories:
         existing_directories[identifier] = tempfile.mkdtemp(
@@ -122,7 +141,17 @@ def make_temp_path(existing_directories, identifier, *args) -> str:
 
 
 def get_library_paths(project_path: str):
-    """..."""
+    """
+    Returns a list of library paths associated with the project located at
+    the specified project location. These are the paths that should be added
+    to the `sys.path` during project execution for the necessary libraries to
+    be available during step testing.
+
+    :param project_path:
+        The path to the Cauldron project to open. It should be either a
+        directory that contains a `cauldron.json` file or a file path to the
+        `cauldron.json` file for the project to load.
+    """
     path = (
         os.path.join(project_path, 'cauldron.json')
         if not project_path.endswith('cauldron.json') else

--- a/cauldron/test/steptesting/S01-first.py
+++ b/cauldron/test/steptesting/S01-first.py
@@ -28,6 +28,7 @@ def create_unified_column(data_frame: pd.DataFrame) -> pd.Series:
 
     return pd.Series(unified)
 
+
 df['d'] = create_unified_column(df)
 
 cd.shared.df = df

--- a/cauldron/test/steptesting/S03-lib-patching.py
+++ b/cauldron/test/steptesting/S03-lib-patching.py
@@ -2,4 +2,5 @@ import cauldron as cd
 import _testlib
 
 value = cd.shared.value
-cd.shared.result = _testlib.patching_test(value)
+result_value = _testlib.patching_test(value)
+cd.shared.result = result_value

--- a/cauldron/test/steptesting/test_functional.py
+++ b/cauldron/test/steptesting/test_functional.py
@@ -11,7 +11,7 @@ from cauldron.steptest import CauldronTest
 
 @CauldronTest()
 def test_first_step(tester: CauldronTest):
-    """ should not be any null/NaN values in df """
+    """Should not be any null/NaN values in df"""
     assert cd.shared.fetch('df') is None
     step = tester.run_step('S01-first.py')
     df = cd.shared.df
@@ -24,7 +24,7 @@ def test_first_step(tester: CauldronTest):
 @CauldronTest()
 def test_second_step(tester: CauldronTest):
     """
-    should fail without exception because of an exception raised in the
+    Should fail without exception because of an exception raised in the
     source but failure is allowed
     """
     step = tester.run_step('S02-errors.py', allow_failure=True)
@@ -37,7 +37,7 @@ def test_second_step(tester: CauldronTest):
 @CauldronTest()
 def test_second_step_strict(tester: CauldronTest):
     """
-    should fail because of an exception raised in the source when strict
+    Should fail because of an exception raised in the source when strict
     failure is enforced
     """
     with pytest.raises(Exception):
@@ -68,7 +68,7 @@ def test_second_step_without_patching(tester: CauldronTest):
 
 @CauldronTest()
 def test_to_strings(tester: CauldronTest):
-    """ should convert list of integers to a list of strings """
+    """Should convert list of integers to a list of strings"""
     before = [1, 2, 3]
     step = tester.run_step('S01-first.py')
     after = step.local.to_strings(before)
@@ -78,7 +78,7 @@ def test_to_strings(tester: CauldronTest):
 
 @CauldronTest()
 def test_modes(tester: CauldronTest):
-    """ should be testing and not interactive or single run """
+    """Should be testing and not interactive or single run"""
     step = tester.run_step('S01-first.py')
     assert step.success
     assert step.local.is_testing
@@ -88,7 +88,7 @@ def test_modes(tester: CauldronTest):
 
 @CauldronTest()
 def test_find_in_current_path(tester: CauldronTest):
-    """ should find a project in this file's directory """
+    """Should find a project in this file's directory"""
     directory = os.path.dirname(os.path.realpath(__file__))
     result = steptest.find_project_directory(directory)
     assert directory == result
@@ -96,7 +96,7 @@ def test_find_in_current_path(tester: CauldronTest):
 
 @CauldronTest()
 def test_find_in_parent_path(tester: CauldronTest):
-    """ should find a project in the parent directory """
+    """Should find a project in the parent directory"""
     directory = os.path.dirname(os.path.realpath(__file__))
     subdirectory = os.path.join(directory, 'fake')
     result = steptest.find_project_directory(subdirectory)
@@ -105,7 +105,7 @@ def test_find_in_parent_path(tester: CauldronTest):
 
 @CauldronTest()
 def test_find_in_grandparent_path(tester: CauldronTest):
-    """ should find a project in the grandparent directory """
+    """Should find a project in the grandparent directory"""
     directory = os.path.dirname(os.path.realpath(__file__))
     subdirectory = os.path.join(directory, 'fake', 'fake')
     result = steptest.find_project_directory(subdirectory)
@@ -126,21 +126,21 @@ def test_find_failed_at_root(tester: CauldronTest):
 
 @CauldronTest()
 def test_make_temp_path(tester: CauldronTest):
-    """ should make a temp path for testing """
+    """Should make a temp path for testing"""
     temp_path = tester.make_temp_path('some-id', 'a', 'b.test')
     assert temp_path.endswith('b.test')
 
 
 @CauldronTest()
 def test_no_such_step(tester: CauldronTest):
-    """ should fail if no such step exists """
+    """Should fail if no such step exists"""
     with pytest.raises(Exception):
         tester.run_step('FAKE-STEP.no-exists')
 
 
 @CauldronTest()
 def test_no_such_project(tester: CauldronTest):
-    """ should fail if no project exists """
+    """Should fail if no project exists"""
     project = cd.project.internal_project
     cd.project.load(None)
 

--- a/cauldron/test/steptesting/test_functional.py
+++ b/cauldron/test/steptesting/test_functional.py
@@ -1,0 +1,159 @@
+import os
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+import cauldron as cd
+from cauldron import steptest
+from cauldron.steptest import CauldronTest
+
+
+@CauldronTest()
+def test_first_step(tester: CauldronTest):
+    """ should not be any null/NaN values in df """
+    assert cd.shared.fetch('df') is None
+    step = tester.run_step('S01-first.py')
+    df = cd.shared.df
+    assert not df.isnull().values.any()
+
+    error_echo = step.echo_error()
+    assert error_echo == ''
+
+
+@CauldronTest()
+def test_second_step(tester: CauldronTest):
+    """
+    should fail without exception because of an exception raised in the
+    source but failure is allowed
+    """
+    step = tester.run_step('S02-errors.py', allow_failure=True)
+    assert not step.success
+
+    error_echo = step.echo_error()
+    assert 0 < len(error_echo)
+
+
+@CauldronTest()
+def test_second_step_strict(tester: CauldronTest):
+    """
+    should fail because of an exception raised in the source when strict
+    failure is enforced
+    """
+    with pytest.raises(Exception):
+        tester.run_step('S02-errors.py', allow_failure=False)
+
+
+@patch('_testlib.patching_test')
+@CauldronTest()
+def test_second_step_with_patching(
+        tester: CauldronTest,
+        patching_test: MagicMock
+):
+    """Should override the return value with the patch"""
+    patching_test.return_value = 12
+    cd.shared.value = 42
+
+    tester.run_step('S03-lib-patching.py')
+    assert 12 == cd.shared.result
+
+
+@CauldronTest()
+def test_second_step_without_patching(tester: CauldronTest):
+    """Should succeed running the step without patching"""
+    cd.shared.value = 42
+    tester.run_step('S03-lib-patching.py')
+    assert 42 == cd.shared.result
+
+
+@CauldronTest()
+def test_to_strings(tester: CauldronTest):
+    """ should convert list of integers to a list of strings """
+    before = [1, 2, 3]
+    step = tester.run_step('S01-first.py')
+    after = step.local.to_strings(before)
+    assert step.success
+    assert ['1', '2', '3'] == after
+
+
+@CauldronTest()
+def test_modes(tester: CauldronTest):
+    """ should be testing and not interactive or single run """
+    step = tester.run_step('S01-first.py')
+    assert step.success
+    assert step.local.is_testing
+    assert not step.local.is_interactive
+    assert not step.local.is_single_run
+
+
+@CauldronTest()
+def test_find_in_current_path(tester: CauldronTest):
+    """ should find a project in this file's directory """
+    directory = os.path.dirname(os.path.realpath(__file__))
+    result = steptest.find_project_directory(directory)
+    assert directory == result
+
+
+@CauldronTest()
+def test_find_in_parent_path(tester: CauldronTest):
+    """ should find a project in the parent directory """
+    directory = os.path.dirname(os.path.realpath(__file__))
+    subdirectory = os.path.join(directory, 'fake')
+    result = steptest.find_project_directory(subdirectory)
+    assert directory == result
+
+
+@CauldronTest()
+def test_find_in_grandparent_path(tester: CauldronTest):
+    """ should find a project in the grandparent directory """
+    directory = os.path.dirname(os.path.realpath(__file__))
+    subdirectory = os.path.join(directory, 'fake', 'fake')
+    result = steptest.find_project_directory(subdirectory)
+    assert directory == result
+
+
+@CauldronTest()
+def test_find_failed_at_root(tester: CauldronTest):
+    """ should return None if top-level directory has no project """
+    directory = os.path.dirname(os.path.realpath(__file__))
+    subdirectory = os.path.join(directory, 'fake')
+
+    with patch('os.path.dirname', return_value=subdirectory) as func:
+        result = steptest.find_project_directory(subdirectory)
+        func.assert_called_once_with(subdirectory)
+    assert result is None
+
+
+@CauldronTest()
+def test_make_temp_path(tester: CauldronTest):
+    """ should make a temp path for testing """
+    temp_path = tester.make_temp_path('some-id', 'a', 'b.test')
+    assert temp_path.endswith('b.test')
+
+
+@CauldronTest()
+def test_no_such_step(tester: CauldronTest):
+    """ should fail if no such step exists """
+    with pytest.raises(Exception):
+        tester.run_step('FAKE-STEP.no-exists')
+
+
+@CauldronTest()
+def test_no_such_project(tester: CauldronTest):
+    """ should fail if no project exists """
+    project = cd.project.internal_project
+    cd.project.load(None)
+
+    with pytest.raises(Exception):
+        tester.run_step('FAKE')
+
+    cd.project.load(project)
+
+
+@CauldronTest()
+def test_open_project_fails(tester: CauldronTest):
+    """Should raise Assertion error after failing to open the project"""
+    with patch('cauldron.steptest.support.open_project') as open_project:
+        open_project.side_effect = RuntimeError('FAKE')
+        with pytest.raises(AssertionError):
+            tester.open_project()

--- a/cauldron/test/steptesting/test_functional.py
+++ b/cauldron/test/steptesting/test_functional.py
@@ -114,14 +114,14 @@ def test_find_in_grandparent_path(tester: CauldronTest):
 
 @CauldronTest()
 def test_find_failed_at_root(tester: CauldronTest):
-    """ should return None if top-level directory has no project """
+    """Should raise FileNotFoundError if top-level directory has no project"""
     directory = os.path.dirname(os.path.realpath(__file__))
     subdirectory = os.path.join(directory, 'fake')
 
     with patch('os.path.dirname', return_value=subdirectory) as func:
-        result = steptest.find_project_directory(subdirectory)
+        with pytest.raises(FileNotFoundError):
+            steptest.find_project_directory(subdirectory)
         func.assert_called_once_with(subdirectory)
-    assert result is None
 
 
 @CauldronTest()

--- a/cauldron/test/steptesting/test_steptest.py
+++ b/cauldron/test/steptesting/test_steptest.py
@@ -1,6 +1,6 @@
 import os
-from unittest.mock import patch
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import cauldron as cd
 from cauldron import steptest
@@ -8,10 +8,10 @@ from cauldron.steptest import StepTestCase
 
 
 class TestStepTesting(StepTestCase):
-    """Tests the step testing module"""
+    """Test suite for the step testing module"""
 
     def test_first_step(self):
-        """ should not be any null/NaN values in df """
+        """Should not be any null/NaN values in df"""
         self.assertIsNone(cd.shared.fetch('df'))
         step = self.run_step('S01-first.py')
         df = cd.shared.df
@@ -22,7 +22,7 @@ class TestStepTesting(StepTestCase):
 
     def test_second_step(self):
         """ 
-        should fail without exception because of an exception raised in the 
+        Should fail without exception because of an exception raised in the
         source but failure is allowed
         """
         step = self.run_step('S02-errors.py', allow_failure=True)
@@ -33,7 +33,7 @@ class TestStepTesting(StepTestCase):
 
     def test_second_step_strict(self):
         """ 
-        should fail because of an exception raised in the source when strict
+        Should fail because of an exception raised in the source when strict
         failure is enforced
         """
         with self.assertRaises(Exception):
@@ -63,7 +63,7 @@ class TestStepTesting(StepTestCase):
         self.assertEqual(['1', '2', '3'], after)
 
     def test_modes(self):
-        """ should be testing and not interactive or single run """
+        """Should be testing and not interactive or single run"""
         step = self.run_step('S01-first.py')
         self.assertTrue(step.success)
         self.assertTrue(step.local.is_testing)
@@ -71,27 +71,27 @@ class TestStepTesting(StepTestCase):
         self.assertFalse(step.local.is_single_run)
 
     def test_find_in_current_path(self):
-        """ should find a project in this file's directory """
+        """Should find a project in this file's directory"""
         directory = os.path.dirname(os.path.realpath(__file__))
         result = steptest.find_project_directory(directory)
         self.assertEqual(directory, result)
 
     def test_find_in_parent_path(self):
-        """ should find a project in the parent directory """
+        """Should find a project in the parent directory"""
         directory = os.path.dirname(os.path.realpath(__file__))
         subdirectory = os.path.join(directory, 'fake')
         result = steptest.find_project_directory(subdirectory)
         self.assertEqual(directory, result)
 
     def test_find_in_grandparent_path(self):
-        """ should find a project in the grandparent directory """
+        """Should find a project in the grandparent directory"""
         directory = os.path.dirname(os.path.realpath(__file__))
         subdirectory = os.path.join(directory, 'fake', 'fake')
         result = steptest.find_project_directory(subdirectory)
         self.assertEqual(directory, result)
 
     def test_find_failed_at_root(self):
-        """ should return None if top-level directory has no project """
+        """Should return None if top-level directory has no project"""
         directory = os.path.dirname(os.path.realpath(__file__))
         subdirectory = os.path.join(directory, 'fake')
 
@@ -101,17 +101,17 @@ class TestStepTesting(StepTestCase):
             func.assert_called_once_with(subdirectory)
 
     def test_make_temp_path(self):
-        """ should make a temp path for testing """
+        """Should make a temp path for testing"""
         temp_path = self.make_temp_path('some-id', 'a', 'b.test')
         self.assertTrue(temp_path.endswith('b.test'))
 
     def test_no_such_step(self):
-        """ should fail if no such step exists """
+        """Should fail if no such step exists"""
         with self.assertRaises(Exception):
             self.run_step('FAKE-STEP.no-exists')
 
     def test_no_such_project(self):
-        """ should fail if no project exists """
+        """Should fail if no project exists"""
         project = cd.project.internal_project
         cd.project.load(None)
 

--- a/cauldron/test/steptesting/test_steptest.py
+++ b/cauldron/test/steptesting/test_steptest.py
@@ -96,9 +96,9 @@ class TestStepTesting(StepTestCase):
         subdirectory = os.path.join(directory, 'fake')
 
         with patch('os.path.dirname', return_value=subdirectory) as func:
-            result = steptest.find_project_directory(subdirectory)
+            with self.assertRaises(FileNotFoundError):
+                steptest.find_project_directory(subdirectory)
             func.assert_called_once_with(subdirectory)
-        self.assertIsNone(result)
 
     def test_make_temp_path(self):
         """ should make a temp path for testing """

--- a/cauldron/test/steptesting/test_steptest.py
+++ b/cauldron/test/steptesting/test_steptest.py
@@ -119,3 +119,10 @@ class TestStepTesting(StepTestCase):
             self.run_step('FAKE')
 
         cd.project.load(project)
+
+    def test_open_project_fails(self):
+        """Should raise Assertion error after failing to open the project"""
+        with patch('cauldron.steptest.support.open_project') as open_project:
+            open_project.side_effect = RuntimeError('FAKE')
+            with self.assertRaises(AssertionError):
+                self.open_project()

--- a/cauldron/test/steptesting/test_support.py
+++ b/cauldron/test/steptesting/test_support.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from cauldron.steptest import support
+
+
+@patch('time.sleep')
+@patch('cauldron.cli.commander.execute')
+@patch('cauldron.project')
+def test_open_project(
+        project: MagicMock,
+        execute: MagicMock,
+        sleep: MagicMock
+):
+    """Should fail to open project and eventually give up"""
+    project.internal_project = None
+    execute.return_value = MagicMock()
+
+    with pytest.raises(RuntimeError):
+        support.open_project('FAKE')
+
+    assert 1 == execute.call_count, """
+        Expected a single execute call to open the project.
+        """
+    assert 101 == sleep.call_count, """
+        Expected sleep to be called repeatedly until the wait period
+        for opening the project times out.
+        """


### PR DESCRIPTION
This PR adds support for the `pytest` framework when running step tests with a new `@CauldronTest` decorator that wraps around a `pytest` function to handle the setup and teardown for each test. The same functionality available in the `StepTestCase` class for the `unittest` framework has been ported to the `@CauldronTest` decorator. A `cauldron.steptest.support` module has been added to hold shared functionality between the two test classes.