### PR TITLE
Project Opening

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,4 @@ omit =
     /conda-recipe/*.py
     /docker-builder.py
     /launcher.py
+    *.py.txt

--- a/cauldron/__init__.py
+++ b/cauldron/__init__.py
@@ -22,14 +22,13 @@ spark = _spark
 
 def get_environment_info() -> dict:
     """
-    Information about Cauldron and its Python interpreter
+    Information about Cauldron and its Python interpreter.
 
     :return:
         A dictionary containing information about the Cauldron and its
         Python environment. This information is useful when providing feedback
-        and bug reports
+        and bug reports.
     """
-
     data = _environ.systems.get_system_data()
     data['cauldron'] = _environ.package_settings.copy()
     return data
@@ -37,7 +36,6 @@ def get_environment_info() -> dict:
 
 def run_shell():
     """ Starts the cauldron shell environment for console based interaction """
-
     from cauldron.cli.shell import CauldronShell
     CauldronShell().cmdloop()
 
@@ -45,7 +43,7 @@ def run_shell():
 def run_server(port=5010, debug=False, **kwargs):
     """
     Run the cauldron http server used to interact with cauldron from a remote
-    host
+    host.
 
     :param port:
         The port on which to bind the cauldron server.
@@ -55,7 +53,6 @@ def run_server(port=5010, debug=False, **kwargs):
     :param kwargs:
         Custom properties to alter the way the server runs.
     """
-
     from cauldron.cli.server import run
     run.execute(port=port, debug=debug, **kwargs)
 
@@ -92,9 +89,8 @@ def run_project(
         Any variables to be available in the cauldron.shared object during
         execution of the project can be specified here as keyword arguments.
     :return:
-        A response object that contains information about the run process
+        A response object that contains information about the run process.
     """
-
     from cauldron.cli import batcher
     return batcher.run_project(
         project_directory=project_directory,

--- a/cauldron/cli/batcher.py
+++ b/cauldron/cli/batcher.py
@@ -89,7 +89,7 @@ def run_project(
     if response.failed:
         return on_complete('[ERROR]: Aborted trying to open project')
 
-    project = cauldron.project.internal_project
+    project = cauldron.project.get_internal_project()
     project.shared.put(**(shared_data if shared_data is not None else dict()))
 
     commander.preload()

--- a/cauldron/cli/commands/open/opener.py
+++ b/cauldron/cli/commands/open/opener.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import cauldron
 from cauldron import environ
@@ -150,7 +151,7 @@ def open_project(
             message='Unable to update loaded project status'
         ).console(whitespace=1).response
 
-    project = cauldron.project.internal_project
+    project = cauldron.project.get_internal_project()
     if results_path:
         project.results_path = results_path
 

--- a/cauldron/cli/server/routes/display.py
+++ b/cauldron/cli/server/routes/display.py
@@ -8,8 +8,7 @@ from cauldron.cli.server import run as server_run
 
 @server_run.APPLICATION.route('/view/<path:route>', methods=['GET', 'POST'])
 def view(route: str):
-
-    project = cauldron.project.internal_project
+    project = cauldron.project.get_internal_project()
     results_path = project.results_path if project else None
     if not project or not results_path:
         return '', 204

--- a/cauldron/cli/server/routes/execution.py
+++ b/cauldron/cli/server/routes/execution.py
@@ -201,7 +201,7 @@ def abort():
         except Exception:
             pass
 
-    project = cd.project.internal_project
+    project = cd.project.get_internal_project()
 
     if project and project.current_step:
         step = project.current_step

--- a/cauldron/cli/server/routes/status.py
+++ b/cauldron/cli/server/routes/status.py
@@ -25,15 +25,11 @@ def server_status():
 @server_runner.APPLICATION.route('/status', methods=['GET', 'POST'])
 @authorization.gatekeeper
 def project_status():
-    """
-
-    :return:
-    """
-
+    """..."""
     r = Response()
 
     try:
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         if project:
             r.update(project=project.status())
         else:
@@ -55,10 +51,9 @@ def project_status():
 )
 @authorization.gatekeeper
 def clean_step(step_name: str):
-    """ """
-
+    """..."""
     r = Response()
-    project = cauldron.project.internal_project
+    project = cauldron.project.get_internal_project()
 
     if not project:
         return flask.jsonify(r.fail(
@@ -92,7 +87,7 @@ def project_data():
     r = Response()
 
     try:
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         if project:
             r.update(project=project.kernel_serialize())
         else:

--- a/cauldron/cli/server/routes/synchronize/__init__.py
+++ b/cauldron/cli/server/routes/synchronize/__init__.py
@@ -27,11 +27,10 @@ sync_status = dict(
 @authorization.gatekeeper
 def touch_project():
     """
-    Touches the project to trigger refreshing its cauldron.json state
+    Touches the project to trigger refreshing its cauldron.json state.
     """
-
     r = Response()
-    project = cd.project.internal_project
+    project = cd.project.get_internal_project()
 
     if project:
         project.refresh()
@@ -53,9 +52,8 @@ def fetch_synchronize_status():
     Returns the synchronization status information for the currently opened
     project
     """
-
     r = Response()
-    project = cd.project.internal_project
+    project = cd.project.get_internal_project()
 
     if not project:
         r.fail(
@@ -152,7 +150,7 @@ def sync_source_file():
             message='Missing or invalid arguments'
         ).response.flask_serialize()
 
-    project = cd.project.internal_project
+    project = cd.project.get_internal_project()
 
     if not project:
         return r.fail(
@@ -201,7 +199,7 @@ def sync_source_file():
 def download_file(filename: str):
     """ downloads the specified project file if it exists """
 
-    project = cd.project.internal_project
+    project = cd.project.get_internal_project()
     source_directory = project.source_directory if project else None
 
     if not filename or not project or not source_directory:
@@ -228,7 +226,7 @@ def download_file(filename: str):
 def download_project_file(filename: str):
     """ downloads the specified project file if it exists """
 
-    project = cd.project.internal_project
+    project = cd.project.get_internal_project()
     source_directory = project.source_directory if project else None
 
     if not filename or not project or not source_directory:
@@ -279,7 +277,7 @@ def sync_create_project():
 
     sync_status.update({}, time=-1, project=None)
 
-    project = cd.project.internal_project
+    project = cd.project.get_internal_project()
     project.remote_source_directory = remote_source_directory
 
     with open(project.source_path, 'r') as f:

--- a/cauldron/cli/server/routes/synchronize/__init__.py
+++ b/cauldron/cli/server/routes/synchronize/__init__.py
@@ -117,7 +117,7 @@ def sync_open_project():
 
     open_response = project_opener.open_project(project_folder, forget=True)
     open_response.join()
-    project = cd.project.internal_project
+    project = cd.project.get_internal_project()
     project.remote_source_directory = source_directory
 
     sync_status.update({}, time=-1, project=project)

--- a/cauldron/cli/server/run.py
+++ b/cauldron/cli/server/run.py
@@ -52,12 +52,8 @@ def get_server_data() -> dict:
 
 
 def get_running_step_changes(write: bool = False) -> list:
-    """
-
-    :return:
-    """
-
-    project = cd.project.internal_project
+    """..."""
+    project = cd.project.get_internal_project()
 
     running_steps = list(filter(
         lambda step: step.is_running,

--- a/cauldron/render/__init__.py
+++ b/cauldron/render/__init__.py
@@ -304,6 +304,7 @@ def plotly(
     return templating.render_template(
         'plotly-component.html',
         dom=dom,
+        scale=scale,
         min_height=round(100.0 * scale),
         id=dom_id
     )

--- a/cauldron/render/texts.py
+++ b/cauldron/render/texts.py
@@ -140,12 +140,7 @@ def text(value: str) -> str:
 
 
 def preformatted_text(source: str) -> str:
-    """
-
-    :param source:
-    :return:
-    """
-
+    """Renders preformatted text box"""
     environ.abort_thread()
 
     if not source:

--- a/cauldron/resources/templates/elapsed_time.html
+++ b/cauldron/resources/templates/elapsed_time.html
@@ -46,8 +46,10 @@
   <div class="cd-ElapsedTime__box">
     <span class="cd-ElapsedTime__header">ELAPSED</span>
     <div class="cd-ElapsedTime__valueBox">
-      <span class="cd-ElapsedTime__value">{{ hours }}</span>
-      <span class="cd-ElapsedTime__separator">:</span>
+      {% if hours != '00' %}
+        <span class="cd-ElapsedTime__value">{{ hours }}</span>
+        <span class="cd-ElapsedTime__separator">:</span>
+      {%  endif %}
       <span class="cd-ElapsedTime__value">{{ minutes }}</span>
       <span class="cd-ElapsedTime__separator">:</span>
       <span class="cd-ElapsedTime__value">{{ seconds }}</span>

--- a/cauldron/resources/templates/plotly-component.html
+++ b/cauldron/resources/templates/plotly-component.html
@@ -1,8 +1,22 @@
-<div class="cd-plotly-box" style="min-height:{{ min_height }}vh">
-  {{ dom }}
-  <script type="application/javascript">
-    setTimeout(function () {
-      window.CAULDRON.resizePlotlyBox('#{{ id }}');
-    }, 250);
-  </script>
+<div class="cd-plotly-box-wrapper">
+  <style scoped>
+    .cd-plotly-box {
+      @supports not (-webkit-overflow-scrolling: touch) {
+        min-height: {{ min_height }}vh;
+      }
+
+      @supports (-webkit-overflow-scrolling: touch) {
+        min-height: {{ scale * 1024 | int }}px;
+        max-height: 1024px;
+      }
+    }
+  </style>
+  <div class="cd-plotly-box">
+    {{ dom }}
+    <script type="application/javascript">
+      setTimeout(function () {
+        window.CAULDRON.resizePlotlyBox('#{{ id }}');
+      }, 500);
+    </script>
+  </div>
 </div>

--- a/cauldron/resources/templates/step-body.html
+++ b/cauldron/resources/templates/step-body.html
@@ -3,6 +3,33 @@
      data-step-name="{{ id }}"
      data-step-updated="{{ last_display_update }}"
 >
+  <style scoped>
+    .cd-step-elapsed {
+      display: none;
+      position: absolute;
+      z-index: 20;
+      background-color: #555;
+      border: 1px solid #444;
+      color: #EEE;
+      padding: 0.25em 1em;
+      align-items: center;
+      right: 0;
+    }
+    .cd-step-elapsed__header {
+      margin-right: 10px;
+    }
+    .cd-step-elapsed__value {
+      font-size: 1.5rem;
+    }
+    .cd-step-stopwatch {
+      margin-right: 10px;
+      margin-top: 2px;
+      cursor: zoom-in;
+    }
+    .cd-step-stopwatch:hover .cd-step-elapsed {
+      display: block;
+    }
+  </style>
   <a class="step-anchor" name="{{ id }}" data-type=""></a>
   <div class="cd-project-step__header cd-project-step__header--standard"
        data-default-modifier="cd-project-step__header--standard"
@@ -29,6 +56,14 @@
     </div>
 
     <div class="spacer"> </div>
+
+    <div class="cd-step-stopwatch">
+      <i class="material-icons md-18">timer</i>
+      <div class="cd-step-elapsed">
+        <div class="cd-step-elapsed__header">Elapsed Time:</div>
+        <div class="cd-step-elapsed__value">{{ elapsed_time }}</div>
+      </div>
+    </div>
 
     <div class="button-bar">
       {% if code %}

--- a/cauldron/runner/__init__.py
+++ b/cauldron/runner/__init__.py
@@ -66,11 +66,7 @@ def initialize(project: typing.Union[str, Project]):
 
 
 def close():
-    """
-
-    :return:
-    """
-
+    """..."""
     os.chdir(os.path.expanduser('~'))
     project = cauldron.project.internal_project
     if not project:
@@ -89,7 +85,7 @@ def reload_libraries(library_directories: list = None):
     directories
     """
     directories = library_directories or []
-    project = cauldron.project.internal_project
+    project = cauldron.project.get_internal_project()
     if project:
         directories += project.library_directories
 
@@ -150,7 +146,7 @@ def section(
     limit = max(1, limit)
 
     if project is None:
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
     starting_index = 0
     if starting:
@@ -202,7 +198,7 @@ def complete(
     """
 
     if project is None:
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
     starting_index = 0
     if starting:

--- a/cauldron/runner/source.py
+++ b/cauldron/runner/source.py
@@ -157,7 +157,10 @@ def run_step(
     )
 
     if result['success']:
-        environ.log('[{}]: Updated'.format(step.definition.name))
+        environ.log('[{}]: Updated in {}'.format(
+            step.definition.name,
+            step.get_elapsed_timestamp()
+        ))
     else:
         response.fail(
             message='Step execution error',

--- a/cauldron/session/buffering.py
+++ b/cauldron/session/buffering.py
@@ -36,7 +36,6 @@ class RedirectBuffer(io.TextIOWrapper):
         :return:
             A string for the current state of the print buffer contents
         """
-
         try:
             buffered_bytes = self.bytes_buffer.getvalue()
             if buffered_bytes is None:
@@ -80,6 +79,15 @@ class RedirectBuffer(io.TextIOWrapper):
             self.last_write_time = time.time()
             super(RedirectBuffer, self).write(*args, **kwargs)
 
+        return self.write_source(*args, **kwargs)
+
+    def write_source(self, *args, **kwargs):
+        """
+        Write only to the redirection source and skip the intermediate
+        intercept buffer. Useful for cases where writing output to the
+        console is desired without it ending up in the notebook display
+        as well.
+        """
         return self.redirection_source.write(*args, **kwargs)
 
     def __getattribute__(self, item):

--- a/cauldron/session/exposed.py
+++ b/cauldron/session/exposed.py
@@ -114,17 +114,17 @@ class ExposedProject(object):
             step is stopped. When False, the notebook display will include
             information relating to the stopped action.
         """
-        step = self.internal_project.current_step
-        if not step:
+        me = self.get_internal_project()
+        if not me or not me.current_step:
             return
 
         if not silent:
-            render_stop_display(step, message)
+            render_stop_display(me.current_step, message)
         raise UserAbortError(halt=True)
 
     def get_internal_project(
             self,
-            timeout: float = 10
+            timeout: float = 3
     ) -> typing.Union['projects.Project', None]:
         """
         Attempts to return the internally loaded project. This function
@@ -136,8 +136,8 @@ class ExposedProject(object):
             Maximum number of seconds to wait before giving up and returning
             None.
         """
-        start_time = time.time()
-        while (time.time() - start_time) < timeout:
+        count = int(timeout / 0.2)
+        for _ in range(count):
             project = self.internal_project
             if project:
                 return project
@@ -163,7 +163,7 @@ class ExposedStep(object):
         """
         import cauldron
         try:
-            return cauldron.project.internal_project.current_step
+            return cauldron.project.get_internal_project().current_step
         except Exception:
             return None
 

--- a/cauldron/session/exposed.py
+++ b/cauldron/session/exposed.py
@@ -25,8 +25,11 @@ class ExposedProject(object):
         self._project = None  # type: projects.Project
 
     @property
-    def internal_project(self) -> projects.Project:
-        """The current Cauldron project that is represented by this object."""
+    def internal_project(self) -> typing.UNION[projects.Project, None]:
+        """
+        The current Cauldron project that is represented by this object.
+        The value will be None if no project has been loaded.
+        """
         return self._project
 
     @property
@@ -36,7 +39,7 @@ class ExposedProject(object):
 
     @property
     def display(self) -> typing.Union[None, report.Report]:
-        """The display report for the current project"""
+        """The display report for the current project."""
         return (
             self._project.current_step.report
             if self._project and self._project.current_step else
@@ -45,17 +48,17 @@ class ExposedProject(object):
 
     @property
     def shared(self) -> typing.Union[None, SharedCache]:
-        """The shared display object associated with this project"""
+        """The shared display object associated with this project."""
         return self._project.shared if self._project else None
 
     @property
     def settings(self) -> typing.Union[None, SharedCache]:
-        """The settings associated with this project"""
+        """The settings associated with this project."""
         return self._project.settings if self._project else None
 
     @property
     def title(self) -> typing.Union[None, str]:
-        """The title of this project"""
+        """The title of this project."""
         return self._project.title if self._project else None
 
     @title.setter
@@ -158,7 +161,6 @@ class ExposedStep(object):
         :return:
             The ProjectStep instance that this ExposedStep represents
         """
-
         import cauldron
         try:
             return cauldron.project.internal_project.current_step
@@ -236,7 +238,7 @@ class ExposedStep(object):
 
 
 def render_stop_display(step: 'projects.ProjectStep', message: str):
-    """Renders a stop action to the Cauldron display"""
+    """Renders a stop action to the Cauldron display."""
     stack = render_stack.get_formatted_stack_frame(
         project=step.project,
         error_stack=False

--- a/cauldron/session/exposed.py
+++ b/cauldron/session/exposed.py
@@ -25,7 +25,7 @@ class ExposedProject(object):
         self._project = None  # type: projects.Project
 
     @property
-    def internal_project(self) -> typing.UNION[projects.Project, None]:
+    def internal_project(self) -> typing.Union[projects.Project, None]:
         """
         The current Cauldron project that is represented by this object.
         The value will be None if no project has been loaded.

--- a/cauldron/session/exposed.py
+++ b/cauldron/session/exposed.py
@@ -1,4 +1,5 @@
 import os
+import time
 import typing
 from datetime import datetime
 
@@ -117,6 +118,29 @@ class ExposedProject(object):
         if not silent:
             render_stop_display(step, message)
         raise UserAbortError(halt=True)
+
+    def get_internal_project(
+            self,
+            timeout: float = 10
+    ) -> typing.Union['projects.Project', None]:
+        """
+        Attempts to return the internally loaded project. This function
+        prevents race condition issues where projects are loaded via threads
+        because the internal loop will try to continuously load the internal
+        project until it is available or until the timeout is reached.
+
+        :param timeout:
+            Maximum number of seconds to wait before giving up and returning
+            None.
+        """
+        start_time = time.time()
+        while (time.time() - start_time) < timeout:
+            project = self.internal_project
+            if project:
+                return project
+            time.sleep(0.2)
+
+        return self.internal_project
 
 
 class ExposedStep(object):

--- a/cauldron/session/projects/steps.py
+++ b/cauldron/session/projects/steps.py
@@ -60,15 +60,12 @@ class ProjectStep(object):
 
     @property
     def uuid(self):
-        """
-
-        :return:
-        """
-
+        """Unique identifier based on the path of the step"""
         return hashlib.sha1(self.source_path.encode()).hexdigest()
 
     @property
     def filename(self) -> str:
+        """Name of the step file"""
         return self.definition.slug
 
     @property
@@ -109,9 +106,20 @@ class ProjectStep(object):
         end = self.end_time or current_time
         return (end - start).total_seconds()
 
+    def get_elapsed_timestamp(self) -> str:
+        """
+        A human-readable version of the elapsed time for the last execution
+        of the step. The value is derived from the `ProjectStep.elapsed_time`
+        property.
+        """
+        t = self.elapsed_time
+        minutes = int(t / 60)
+        seconds = int(t - (60 * minutes))
+        millis = int(100 * (t - int(t)))
+        return '{:>02d}:{:>02d}.{:<02d}'.format(minutes, seconds, millis)
+
     def kernel_serialize(self):
         """ """
-
         status = self.status()
         out = dict(
             slug=self.definition.slug,
@@ -146,7 +154,6 @@ class ProjectStep(object):
 
     def is_dirty(self):
         """ """
-
         if self._is_dirty:
             return self._is_dirty
 
@@ -183,11 +190,7 @@ class ProjectStep(object):
         return dom
 
     def dumps(self) -> str:
-        """
-
-        :return:
-        """
-
+        """Writes the step information to an HTML-formatted string"""
         code_file_path = os.path.join(
             self.project.source_directory,
             self.filename
@@ -236,6 +239,7 @@ class ProjectStep(object):
         dom = templating.render_template(
             'step-body.html',
             last_display_update=self.report.last_update_time,
+            elapsed_time=self.get_elapsed_timestamp(),
             code=code,
             body=body,
             has_body=has_body,

--- a/cauldron/session/reloading.py
+++ b/cauldron/session/reloading.py
@@ -127,7 +127,7 @@ def reload_module(
         return False
 
     try:
-        step = session.project.internal_project.current_step
+        step = session.project.get_internal_project().current_step
         modified = step.last_modified if step else None
     except AttributeError:
         modified = 0

--- a/cauldron/settings.json
+++ b/cauldron/settings.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.5",
+  "version": "0.3.6",
   "notebookVersion": "v1"
 }

--- a/cauldron/test/cli/commands/test_close.py
+++ b/cauldron/test/cli/commands/test_close.py
@@ -11,7 +11,7 @@ class TestClose(scaffolds.ResultsTest):
         support.run_command('open @examples:hello_cauldron')
         response = support.run_command('close')
         self.assertTrue(response.success, 'should not have failed')
-        self.assertIsNone(cauldron.project.internal_project)
+        self.assertIsNone(cauldron.project.get_internal_project())
 
     def test_no_open_project(self):
         """Should not close when no project is open"""

--- a/cauldron/test/cli/commands/test_create.py
+++ b/cauldron/test/cli/commands/test_create.py
@@ -155,7 +155,7 @@ class TestCreate(scaffolds.ResultsTest):
         )
         self.assertFalse(result.failed)
 
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
 
         items = os.listdir(project.source_directory)
 

--- a/cauldron/test/cli/commands/test_export.py
+++ b/cauldron/test/cli/commands/test_export.py
@@ -66,7 +66,7 @@ class TestExport(scaffolds.ResultsTest):
         self.assertFalse(r.failed, 'should not have failed')
         self.assertTrue(os.path.exists(out_path) and os.path.isdir(out_path))
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         os.makedirs(os.path.join(
             project.results_path,

--- a/cauldron/test/cli/commands/test_open_opener.py
+++ b/cauldron/test/cli/commands/test_open_opener.py
@@ -18,72 +18,77 @@ def opener_package(*args) -> str:
 class TestOpenOpener(scaffolds.ResultsTest):
     """ """
 
-    def test_not_exists(self):
+    @patch('time.sleep')
+    def test_not_exists(self,  *args):
         """ should return False when the project does not exist """
-
         self.assertFalse(opener.project_exists(Response(), INVALID_PATH))
 
-    def test_not_exists_load(self):
+    @patch('time.sleep')
+    def test_not_exists_load(self, *args):
         """ should return False when the project does not exist """
-
         self.assertFalse(opener.load_project(Response(), INVALID_PATH))
 
-    def test_not_exists_open(self):
+    @patch('time.sleep')
+    def test_not_exists_open(self, *args):
         """ should fail when the project does not exist """
-
         response = opener.open_project(INVALID_PATH, forget=True)
         self.assertTrue(response.failed)
 
+    @patch('time.sleep')
     @patch(opener_package('project_exists'), return_value=True)
-    def test_not_loadable_open(self, project_exists):
+    def test_not_loadable_open(self, *args):
         """ should fail when project does not load """
-
         response = opener.open_project(INVALID_PATH, forget=True)
         self.assertTrue(response.failed)
 
+    @patch('time.sleep')
     @patch(opener_package('project_exists'), return_value=True)
     @patch(opener_package('load_project'), return_value=True)
     @patch(opener_package('update_recent_paths'), return_value=False)
     def test_not_update(self, *args):
         """ should fail when project does not load """
-
         response = opener.open_project(INVALID_PATH, forget=False)
         self.assertTrue(response.failed)
 
+    @patch('time.sleep')
     @patch(opener_package('initialize_results'), return_value=False)
     def test_bad_initialize_results(self, *args):
         """ should fail opening when initialization fails """
-
         response = support.create_project(self, 'minnesota', confirm=False)
         self.assertTrue(response.failed)
 
+    @patch('time.sleep')
     @patch(opener_package('write_results'), return_value=False)
     def test_bad_write_results(self, *args):
         """ should fail opening when writing initial results fails """
-
         response = support.create_project(self, 'iowa', confirm=False)
         self.assertTrue(response.failed)
 
+    @patch('time.sleep')
     @patch('cauldron.runner.initialize')
-    def test_load_project_bad(self, runner_initialize):
+    def test_load_project_bad(self, runner_initialize, *args):
         runner_initialize.side_effect = FileNotFoundError()
 
         response = Response()
         self.assertFalse(opener.load_project(response, INVALID_PATH))
         self.assertTrue(response.errors[0].code == 'PROJECT_NOT_FOUND')
 
+    @patch('time.sleep')
     @patch('cauldron.runner.initialize')
-    def test_load_project_bad_2(self, runner_initialize):
+    def test_load_project_bad_2(self, runner_initialize, *args):
         runner_initialize.side_effect = ValueError()
-
         response = Response()
         self.assertFalse(opener.load_project(response, INVALID_PATH))
         self.assertTrue(response.errors[0].code == 'PROJECT_INIT_FAILURE')
 
+    @patch('time.sleep')
     @patch('cauldron.session.initialize_results_path')
-    def test_initialize_results_abort(self, initialize_results_path: MagicMock):
+    def test_initialize_results_abort(
+            self,
+            initialize_results_path: MagicMock,
+            *args
+    ):
         """Should abort initializing project has no results path"""
-
         response = Response()
         project = MagicMock()
         project.results_path = None
@@ -91,20 +96,28 @@ class TestOpenOpener(scaffolds.ResultsTest):
         self.assertTrue(result)
         self.assertEqual(0, initialize_results_path.call_count)
 
+    @patch('time.sleep')
     @patch('cauldron.session.initialize_results_path')
-    def test_initialize_results(self, initialize_results_path: MagicMock):
+    def test_initialize_results(
+            self,
+            initialize_results_path: MagicMock,
+            *args
+    ):
         """Should initialize paths for project"""
-
         response = Response()
         project = MagicMock()
         result = opener.initialize_results(response, project)
         self.assertTrue(result)
         self.assertEqual(1, initialize_results_path.call_count)
 
+    @patch('time.sleep')
     @patch('cauldron.session.initialize_results_path')
-    def test_initialize_results_error(self, initialize_results_path: MagicMock):
+    def test_initialize_results_error(
+            self,
+            initialize_results_path: MagicMock,
+            *args
+    ):
         """Should fail to initialize paths for project"""
-
         initialize_results_path.side_effect = ValueError('FAKE')
         response = Response()
         project = MagicMock()

--- a/cauldron/test/cli/commands/test_reload.py
+++ b/cauldron/test/cli/commands/test_reload.py
@@ -9,21 +9,19 @@ class TestReload(scaffolds.ResultsTest):
 
     def test_reload(self):
         """ should reload the currently opened project """
-
         support.run_command('open @examples:hello_cauldron')
         r = support.run_command('reload')
         self.assertFalse(r.failed, 'should not have failed')
 
     def test_no_open_project(self):
         """ should fail when no project is open """
-
         r = support.run_command('reload')
         self.assertTrue(r.failed, 'should have failed')
         self.assertEqual(r.errors[0].code, 'NO_PROJECT_FOUND')
 
-    def test_missing_project_path(self):
+    @patch('time.sleep')
+    def test_missing_project_path(self, *args):
         """ should fail if the project directory does not exist """
-
         support.run_command('open @examples:hello_cauldron')
 
         with patch('os.path.exists') as path_exists:
@@ -33,9 +31,9 @@ class TestReload(scaffolds.ResultsTest):
         self.assertTrue(r.failed, 'should have failed')
         self.assertEqual(r.errors[0].code, 'MISSING_PROJECT_PATH')
 
-    def test_initialize_failure(self):
+    @patch('time.sleep')
+    def test_initialize_failure(self, *args):
         """ should fail if cannot initialize project """
-
         support.run_command('open @examples:hello_cauldron')
 
         with patch('cauldron.runner.initialize') as runner_initialize:
@@ -47,7 +45,6 @@ class TestReload(scaffolds.ResultsTest):
 
     def test_reload_remote(self):
         """ should reload the currently opened project """
-
         support.run_command('open @examples:hello_cauldron')
         r = support.run_remote_command('reload')
         self.assertFalse(r.failed, 'should not have failed')

--- a/cauldron/test/cli/commands/test_run.py
+++ b/cauldron/test/cli/commands/test_run.py
@@ -89,7 +89,7 @@ class TestRun(scaffolds.ResultsTest):
         support.create_project(self, 'crystal')
         support.add_step(self)
 
-        step = cauldron.project.internal_project.steps[0]
+        step = cauldron.project.get_internal_project().steps[0]
 
         result = support.autocomplete('run {}'.format(step.filename[:2]))
         self.assertEqual(len(result), 1)
@@ -114,7 +114,7 @@ class TestRun(scaffolds.ResultsTest):
         support.add_step(self)
         support.add_step(self)
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         step_names = [s.filename for s in project.steps[:-1]]
 
         r = run.execute(
@@ -135,7 +135,7 @@ class TestRun(scaffolds.ResultsTest):
         support.add_step(self)
         support.add_step(self)
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         r = run.execute(
             context=cli.make_command_context(name=run.NAME),
@@ -165,7 +165,7 @@ class TestRun(scaffolds.ResultsTest):
         support.add_step(self)
         support.add_step(self)
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         r = run.execute(
             context=cli.make_command_context(name=run.NAME),
@@ -184,7 +184,7 @@ class TestRun(scaffolds.ResultsTest):
         support.add_step(self)
         support.add_step(self)
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         step_names = [s.filename for s in project.steps[:-1]]
         step_names.append(project.steps[0].filename)
 
@@ -206,7 +206,7 @@ class TestRun(scaffolds.ResultsTest):
         support.add_step(self)
         support.add_step(self)
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         step_names = [
             project.steps[1].filename,
             project.steps[0].filename,
@@ -230,7 +230,7 @@ class TestRun(scaffolds.ResultsTest):
         support.add_step(self)
         support.add_step(self)
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         step_names = [s.filename for s in project.steps]
         step_names.append('FAKE-STEP')
 
@@ -247,7 +247,9 @@ class TestRun(scaffolds.ResultsTest):
         support.create_project(self, 'rhino')
         support.add_step(self, contents='print("hello!")')
 
-        source_directory = cauldron.project.internal_project.source_directory
+        source_directory = (
+            cauldron.project.get_internal_project().source_directory
+        )
 
         opened_response = support.run_remote_command(
             'open "{}"'.format(source_directory)
@@ -266,7 +268,9 @@ class TestRun(scaffolds.ResultsTest):
         support.create_project(self, 'pig')
         support.add_step(self, contents='print("hello!")')
 
-        source_directory = cauldron.project.internal_project.source_directory
+        source_directory = (
+            cauldron.project.get_internal_project().source_directory
+        )
 
         opened_response = support.run_remote_command(
             'open "{}"'.format(source_directory)

--- a/cauldron/test/cli/commands/test_save.py
+++ b/cauldron/test/cli/commands/test_save.py
@@ -41,7 +41,7 @@ class TestSave(scaffolds.ResultsTest):
         self.assertFalse(r.failed)
         self.assertTrue(os.path.exists(r.data['path']))
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         self.assertTrue(
             r.data['path'].endswith('{}.cauldron'.format(project.title))
         )
@@ -84,7 +84,7 @@ class TestSave(scaffolds.ResultsTest):
         download_file.return_value = Response().fail().response
 
         support.create_project(self, 'apophis')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         support.run_remote_command('open "{}"'.format(project.source_directory))
 
@@ -98,7 +98,7 @@ class TestSave(scaffolds.ResultsTest):
         download_file.return_value = Response()
 
         support.create_project(self, 'apophis')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         support.run_remote_command('open "{}"'.format(project.source_directory))
 

--- a/cauldron/test/cli/commands/test_show.py
+++ b/cauldron/test/cli/commands/test_show.py
@@ -21,7 +21,7 @@ class TestShow(scaffolds.ResultsTest):
         """ should show local project """
 
         support.run_command('open @examples:hello_cauldron')
-        url = cauldron.project.internal_project.baked_url
+        url = cauldron.project.get_internal_project().baked_url
 
         with patch('webbrowser.open') as func:
             r = support.run_command('show')
@@ -41,7 +41,7 @@ class TestShow(scaffolds.ResultsTest):
             remote_connection=remote_connection
         )
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         url = project.make_remote_url(remote_connection.url)
 
         with patch('webbrowser.open') as func:

--- a/cauldron/test/cli/commands/test_step_actions.py
+++ b/cauldron/test/cli/commands/test_step_actions.py
@@ -34,7 +34,7 @@ class TestStepActions(scaffolds.ResultsTest):
         """ should return default value if bad string is supplied """
 
         support.create_project(self, 'ray')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         result = step_actions.index_from_location(None, project, '12s', 42)
         self.assertEqual(result, 42)
@@ -44,7 +44,7 @@ class TestStepActions(scaffolds.ResultsTest):
 
         support.create_project(self, 'bradbury')
         support.add_step(self)
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         step = project.steps[0]
 
         result = step_actions.index_from_location(None, project, step.filename)
@@ -54,7 +54,7 @@ class TestStepActions(scaffolds.ResultsTest):
         """ should fail to mute a step that does not exist """
 
         support.create_project(self, 'lewis')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         r = Response()
         step_actions.toggle_muting(r, project, 'not-a-step')
@@ -68,7 +68,7 @@ class TestStepActions(scaffolds.ResultsTest):
         support.create_project(self, 'carrol')
         support.add_step(self)
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         step = project.steps[0]
         self.assertFalse(step.is_muted)
 

--- a/cauldron/test/cli/commands/test_steps.py
+++ b/cauldron/test/cli/commands/test_steps.py
@@ -7,14 +7,10 @@ from cauldron.test.support.messages import Message
 
 
 class TestSteps(scaffolds.ResultsTest):
-    """
-
-    """
+    """Test suite for the steps module"""
 
     def test_steps_add(self):
-        """
-        """
-
+        """Should add a step"""
         support.create_project(self, 'bob')
         project = cauldron.project.internal_project
 
@@ -25,9 +21,7 @@ class TestSteps(scaffolds.ResultsTest):
         ))
 
     def test_steps_muting(self):
-        """
-        """
-
+        """Should mute a step"""
         support.create_project(self, 'larry')
 
         support.run_command('steps add first.py')
@@ -39,9 +33,7 @@ class TestSteps(scaffolds.ResultsTest):
         self.assertFalse(r.failed, 'should nto have failed')
 
     def test_steps_modify(self):
-        """
-        """
-
+        """Should modify a step"""
         response = support.create_project(self, 'lindsey')
         self.assertFalse(
             response.failed,
@@ -68,9 +60,7 @@ class TestSteps(scaffolds.ResultsTest):
         )
 
     def test_steps_remove(self):
-        """
-        """
-
+        """Should remove a step"""
         support.create_project(self, 'angelica')
 
         r = support.run_command('steps add first.py')
@@ -83,7 +73,6 @@ class TestSteps(scaffolds.ResultsTest):
         self.assertTrue(r.failed, 'should have failed')
 
     def test_steps_remove_renaming(self):
-
         STEP_COUNT = 6
 
         support.create_project(self, 'bellatrix')
@@ -102,9 +91,7 @@ class TestSteps(scaffolds.ResultsTest):
             self.assertEqual('S0{}.py'.format(i + 1), step_names[i])
 
     def test_steps_list(self):
-        """
-        """
-
+        """Should list steps"""
         support.create_project(self, 'angelica')
         r = support.run_command('steps list')
         self.assertEqual(len(r.data['steps']), 0, Message(
@@ -120,11 +107,7 @@ class TestSteps(scaffolds.ResultsTest):
         self.assertFalse(r.failed, 'should not have failed')
 
     def test_autocomplete(self):
-        """
-
-        :return:
-        """
-
+        """Should autocomplete steps command"""
         support.create_project(self, 'gina')
         support.add_step(self, 'a.py')
         support.add_step(self, 'b.py')
@@ -148,11 +131,7 @@ class TestSteps(scaffolds.ResultsTest):
         )
 
     def test_modify_move(self):
-        """
-
-        :return:
-        """
-
+        """..."""
         support.create_project(self, 'harvey')
         support.add_step(self, contents='#S1')
         support.add_step(self, contents='#S2')
@@ -180,8 +159,7 @@ class TestSteps(scaffolds.ResultsTest):
         ))
 
     def test_remote(self):
-        """ should function remotely """
-
+        """Should function remotely"""
         support.create_project(self, 'nails')
         project = cauldron.project.internal_project
 

--- a/cauldron/test/cli/commands/test_steps.py
+++ b/cauldron/test/cli/commands/test_steps.py
@@ -12,7 +12,7 @@ class TestSteps(scaffolds.ResultsTest):
     def test_steps_add(self):
         """Should add a step"""
         support.create_project(self, 'bob')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         r = support.run_command('steps add first.py')
         self.assertFalse(r.failed, 'should not have failed')
@@ -43,7 +43,7 @@ class TestSteps(scaffolds.ResultsTest):
             )
         )
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         directory = project.source_directory
 
         r = support.run_command('steps add first.py')
@@ -84,7 +84,7 @@ class TestSteps(scaffolds.ResultsTest):
         r = support.run_command('steps remove S02.py')
         self.assertFalse(r.failed, 'Removal should have succeeded')
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         step_names = [s.definition.name for s in project.steps]
 
         for i in range(STEP_COUNT - 1):
@@ -161,12 +161,12 @@ class TestSteps(scaffolds.ResultsTest):
     def test_remote(self):
         """Should function remotely"""
         support.create_project(self, 'nails')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         support.run_remote_command('open "{}" --forget'.format(
             project.source_directory
         ))
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         added_response = support.run_remote_command('steps add')
         self.assertTrue(added_response.success, Message(

--- a/cauldron/test/cli/commands/test_steps_create_step.py
+++ b/cauldron/test/cli/commands/test_steps_create_step.py
@@ -15,7 +15,7 @@ class TestStepsCreateStep(scaffolds.ResultsTest):
         """ should convert float index to integer """
 
         support.create_project(self, 'minneapolis')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         project.naming_scheme = None
 
         r = Response()
@@ -34,7 +34,7 @@ class TestStepsCreateStep(scaffolds.ResultsTest):
         synchronize_step_names.return_value = failedResponse
 
         support.create_project(self, 'st-paul')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         r = Response()
         step_actions.create_step(r, project, '', '', 'This is my step')

--- a/cauldron/test/cli/commands/test_steps_insert.py
+++ b/cauldron/test/cli/commands/test_steps_insert.py
@@ -13,7 +13,7 @@ class TestStepsInsert(scaffolds.ResultsTest):
         support.add_step(self)
         support.add_step(self, position='0')
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         steps = project.steps
 
         self.assertTrue(steps[0].filename.startswith('S01'))
@@ -26,7 +26,7 @@ class TestStepsInsert(scaffolds.ResultsTest):
         support.add_step(self)
         support.add_step(self, name='.md', position='0')
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         steps = project.steps
 
         self.assertTrue(steps[0].filename.startswith('S01'))
@@ -41,7 +41,7 @@ class TestStepsInsert(scaffolds.ResultsTest):
         support.add_step(self)
         support.add_step(self, name='.md', position='0')
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         steps = project.steps
 
         self.assertTrue(steps[0].filename.startswith('S01'))
@@ -58,7 +58,7 @@ class TestStepsInsert(scaffolds.ResultsTest):
         support.add_step(self, name='C')
         support.add_step(self, name='D.md', position='0')
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         steps = project.steps
 
         self.assertTrue(steps[0].filename.startswith('S01-D'))

--- a/cauldron/test/cli/commands/test_steps_modify_step.py
+++ b/cauldron/test/cli/commands/test_steps_modify_step.py
@@ -21,7 +21,7 @@ class TestStepsCreateStep(scaffolds.ResultsTest):
         support.add_step(self, 'second')
         support.add_step(self, 'third')
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         r = Response()
         result = step_actions.modify_step(
@@ -42,7 +42,7 @@ class TestStepsCreateStep(scaffolds.ResultsTest):
         support.create_project(self, 'bloomington')
         support.add_step(self, 'first')
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         step = project.steps[0]
         r = Response()
 
@@ -59,7 +59,7 @@ class TestStepsCreateStep(scaffolds.ResultsTest):
         support.create_project(self, 'richfield')
         support.add_step(self, 'first')
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         step = project.steps[0]
         r = Response()
 
@@ -84,7 +84,7 @@ class TestStepsCreateStep(scaffolds.ResultsTest):
         """ should rename properly a nameless step """
 
         support.create_project(self, 'columbia-heights')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         project.naming_scheme = None
 
         support.add_step(self)
@@ -113,7 +113,7 @@ class TestStepsCreateStep(scaffolds.ResultsTest):
         support.create_project(self, 'blaine')
         support.add_step(self)
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         r = Response()
         step_actions.modify_step(

--- a/cauldron/test/cli/commands/test_sync.py
+++ b/cauldron/test/cli/commands/test_sync.py
@@ -16,7 +16,7 @@ class TestSync(scaffolds.ResultsTest):
         response = support.run_remote_command('sync')
         self.assertTrue(response.success)
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         remote_files = sorted(os.listdir(project.remote_source_directory))
         local_files = sorted(os.listdir(project.source_directory))
 

--- a/cauldron/test/cli/server/routes/synchronize/test_project_download.py
+++ b/cauldron/test/cli/server/routes/synchronize/test_project_download.py
@@ -28,7 +28,7 @@ class TestProjectDownload(FlaskResultsTest):
 
         support.create_project(self, 'project-downloader-2')
         support.add_step(self)
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         step_name = project.steps[0].filename
 
         support.run_remote_command('open "{}"'.format(project.source_directory))

--- a/cauldron/test/cli/server/routes/synchronize/test_status.py
+++ b/cauldron/test/cli/server/routes/synchronize/test_status.py
@@ -41,7 +41,7 @@ class TestStatus(scaffolds.ResultsTest):
         """ should return information about the project """
 
         support.create_project(self, 'eric')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         results = status.of_project(project)
 
         self.assertEqual(len(results['libraries']), 2)

--- a/cauldron/test/cli/server/routes/synchronize/test_sync_create.py
+++ b/cauldron/test/cli/server/routes/synchronize/test_sync_create.py
@@ -46,5 +46,5 @@ class TestSyncCreate(FlaskResultsTest):
         response = created.response
         self.assert_has_success_code(response, 'PROJECT_CREATED')
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         self.assertEqual(project.remote_source_directory, source_directory)

--- a/cauldron/test/cli/server/routes/synchronize/test_sync_download.py
+++ b/cauldron/test/cli/server/routes/synchronize/test_sync_download.py
@@ -27,7 +27,7 @@ class TestSyncDownload(FlaskResultsTest):
         """ should successfully download file """
 
         support.create_project(self, 'downloader')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         support.run_remote_command('open "{}"'.format(project.source_directory))
 

--- a/cauldron/test/cli/server/routes/synchronize/test_sync_file.py
+++ b/cauldron/test/cli/server/routes/synchronize/test_sync_file.py
@@ -49,13 +49,13 @@ class TestSyncFile(FlaskResultsTest):
         """ should synchronize file remotely """
 
         support.create_project(self, 'peter')
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         response = support.run_remote_command(
             'open "{}"'.format(project.source_directory)
         )
         self.assert_no_errors(response)
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         posted = self.post('/sync-file', {
             'relative_path': 'test.md',

--- a/cauldron/test/cli/server/routes/synchronize/test_sync_open.py
+++ b/cauldron/test/cli/server/routes/synchronize/test_sync_open.py
@@ -60,5 +60,5 @@ class TestSyncOpen(FlaskResultsTest):
         response = opened.response
         self.assert_has_success_code(response, 'PROJECT_OPENED')
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         self.assertEqual(project.remote_source_directory, source_directory)

--- a/cauldron/test/cli/server/test_server_status.py
+++ b/cauldron/test/cli/server/test_server_status.py
@@ -61,7 +61,7 @@ class TestServerStatus(flask_scaffolds.FlaskResultsTest):
         support.create_project(self, 'luigi')
         support.add_step(self)
 
-        step = cauldron.project.internal_project.steps[0]
+        step = cauldron.project.get_internal_project().steps[0]
 
         cleaned = self.get('/clean-step/{}'.format(step.filename))
         self.assertEqual(cleaned.flask.status_code, 200)

--- a/cauldron/test/cli/test_batcher.py
+++ b/cauldron/test/cli/test_batcher.py
@@ -81,7 +81,6 @@ class TestBatcher(scaffolds.ResultsTest):
 
     def test_run_open_fail(self):
         """Should fail to open a project"""
-
         directory = self.get_temp_path('open-fail')
         result = run_project('fake-project-does-not-exist', directory)
         self.assertFalse(result.response.success)

--- a/cauldron/test/environ/test_logger.py
+++ b/cauldron/test/environ/test_logger.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch
+from unittest.mock import MagicMock
+
+from cauldron.environ import logger
+
+
+@patch('cauldron.environ.logger.log')
+def test_header_zero(log: MagicMock):
+    """Should log a level zero header without modification"""
+    logger.header('hello', level=0)
+    args = log.call_args[0]
+    assert 'hello' == args[0], 'Message should not be modified'
+
+
+@patch('cauldron.environ.logger.log')
+def test_header_infinity(log: MagicMock):
+    """Should log a high level header without modification"""
+    logger.header('hello', level=8)
+    args = log.call_args[0]
+    assert 'hello' == args[0], 'Message should not be modified'
+
+
+@patch('cauldron.environ.logger.raw')
+def test_log_with_kwargs(raw: MagicMock):
+    """Should include kwargs in log output"""
+    message = logger.log('test', foo=42)
+    assert 1 == raw.call_count
+    assert 0 < message.find('foo: 42'), """
+        Expected to find the foo kwarg in the message.
+        """
+
+
+@patch('traceback.extract_tb')
+def test_get_error_stack_module(extract_tb: MagicMock):
+    """Should nullify location when the location is module"""
+    frame = MagicMock()
+    frame.name = '<module>'
+    extract_tb.return_value = [frame]
+    result = logger.get_error_stack()
+    assert result[0]['location'] is None, """
+        Expected a <module> value to be changed to `None`.
+        """
+
+
+@patch('traceback.extract_tb')
+def test_get_error_stack(extract_tb: MagicMock):
+    """Should remove prefix when location is a remote shared library path"""
+    frame = MagicMock()
+    frame.name = '/tmp/cd-remote/__cauldron_shared_libs/test'
+    extract_tb.return_value = [frame]
+    result = logger.get_error_stack()
+    assert result[0]['location'] == '/test', """
+        Expected the remote prefix to be removed.
+        """

--- a/cauldron/test/projects/test_Project.py
+++ b/cauldron/test/projects/test_Project.py
@@ -17,7 +17,7 @@ class TestProject(scaffolds.ResultsTest):
         """A file source directory should be a directory"""
 
         support.create_project(self, 'lupin')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
 
         p = projects.Project(project.source_path)
         self.assertTrue(os.path.isdir(p.source_directory))
@@ -27,7 +27,7 @@ class TestProject(scaffolds.ResultsTest):
         """A dict shared argument should be converted into a SharedCache"""
 
         support.create_project(self, 'tonks')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
 
         shared_data = {'a': 1, 'b': True}
         p = projects.Project(project.source_directory, shared=shared_data)
@@ -41,7 +41,7 @@ class TestProject(scaffolds.ResultsTest):
         """Project title should be readable and writable"""
 
         support.create_project(self, 'sirius')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
 
         title = 'My Title'
         project.title = title
@@ -57,7 +57,7 @@ class TestProject(scaffolds.ResultsTest):
             )
 
         support.create_project(self, 'dudley')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
 
         project._results_path = None
         assert_valid_path(project.results_path)
@@ -79,7 +79,7 @@ class TestProject(scaffolds.ResultsTest):
         """Should not have an error"""
 
         support.create_project(self, 'vernon')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
 
         self.assertFalse(project.has_error, 'error on project without steps')
 
@@ -95,7 +95,7 @@ class TestProject(scaffolds.ResultsTest):
         """Should have error if step raises an error when run"""
 
         support.create_project(self, 'petunia')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
 
         support.add_step(self, contents='raise Exception("test")')
         support.run_command('run')
@@ -106,7 +106,7 @@ class TestProject(scaffolds.ResultsTest):
         """Should not find a step that doesn't exist"""
 
         support.create_project(self, 'luna')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
 
         support.add_step(self)
         support.add_step(self)

--- a/cauldron/test/projects/test_ProjectStep.py
+++ b/cauldron/test/projects/test_ProjectStep.py
@@ -1,36 +1,40 @@
+from datetime import datetime
+from datetime import timedelta
+
 from cauldron.session import projects
-from cauldron.test.support import scaffolds
 
 
-class TestProjectStep(scaffolds.ResultsTest):
+def test_no_project_defaults():
     """
-
+    A ProjectStep without a Project reference should properly default
+    its properties and values
     """
+    ps = projects.ProjectStep()
+    assert -1 == ps.index
+    assert [] == ps.web_includes
+    assert ps.source_path is None
 
-    def test_no_project_defaults(self):
-        """
-        A ProjectStep without a Project reference should properly default
-        its properties and values
-        """
 
-        ps = projects.ProjectStep()
+def test_is_dirty_branches():
+    """
+    ProjectStep should remain dirty until it has been properly
+    initialized and run
+    """
+    ps = projects.ProjectStep()
+    assert ps.is_dirty(), 'Expected to always starts dirty'
 
-        self.assertEqual(ps.index, -1)
-        self.assertEqual(ps.web_includes, [])
-        self.assertIsNone(ps.source_path)
+    ps._is_dirty = False
+    assert ps.is_dirty(), 'Expected dirty because not modified is None'
 
-    def test_is_dirty_branches(self):
-        """
-        ProjectStep should remain dirty until it has been properly
-        initialized and run
-        """
+    ps.last_modified = 1
+    assert not ps.is_dirty(), 'Expected not dirty without valid source path'
 
-        ps = projects.ProjectStep()
 
-        self.assertTrue(ps.is_dirty(), 'always starts dirty')
-
-        ps._is_dirty = False
-        self.assertTrue(ps.is_dirty(), 'dirty because not modified is None')
-
-        ps.last_modified = 1
-        self.assertFalse(ps.is_dirty(), 'not dirty without a valid source path')
+def test_elapsed_time():
+    """Should return correct elapsed timestamp as a string"""
+    dt = datetime.utcnow()
+    ps = projects.ProjectStep()
+    ps.start_time = dt
+    ps.end_time = dt + timedelta(seconds=128.252525)
+    result = ps.get_elapsed_timestamp()
+    assert '02:08.25' == result

--- a/cauldron/test/projects/test_exposed.py
+++ b/cauldron/test/projects/test_exposed.py
@@ -1,3 +1,7 @@
+from unittest.mock import patch
+from unittest.mock import MagicMock
+from unittest.mock import PropertyMock
+
 import cauldron as cd
 from cauldron.session import exposed
 from cauldron.test import support
@@ -136,3 +140,43 @@ class TestExposed(scaffolds.ResultsTest):
 
         self.assertEqual(project.shared.fetch('test'), 1)
         self.assertEqual(-1, step.dom.find('cd-StepStop'))
+
+    @patch(
+        'cauldron.session.exposed.ExposedProject.internal_project',
+        new_callable=PropertyMock
+    )
+    @patch('time.sleep')
+    def test_get_internal_project(
+            self,
+            sleep: MagicMock,
+            internal_project: PropertyMock
+    ):
+        """Should get internal project on the third attempt"""
+        project = exposed.ExposedProject()
+        internal_project.side_effect = [None, None, 'test']
+        result = project.get_internal_project()
+        self.assertEqual('test', result)
+        self.assertEqual(2, sleep.call_count)
+
+    @patch(
+        'cauldron.session.exposed.ExposedProject.internal_project',
+        new_callable=PropertyMock
+    )
+    @patch('time.time')
+    @patch('time.sleep')
+    def test_get_internal_project_fail(
+            self,
+            sleep: MagicMock,
+            time_time: MagicMock,
+            internal_project: PropertyMock
+    ):
+        """
+        Should fail to get internal project and return None after
+        eventually timing out.
+        """
+        project = exposed.ExposedProject()
+        time_time.side_effect = range(20)
+        internal_project.return_value = None
+        result = project.get_internal_project()
+        self.assertIsNone(result)
+        self.assertEqual(9, sleep.call_count)

--- a/cauldron/test/projects/test_exposed.py
+++ b/cauldron/test/projects/test_exposed.py
@@ -60,7 +60,7 @@ class TestExposed(scaffolds.ResultsTest):
         ]))
 
         support.run_command('run')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         self.assertEqual(project.shared.fetch('test'), 1)
@@ -86,7 +86,7 @@ class TestExposed(scaffolds.ResultsTest):
         ]))
 
         support.run_command('run')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         self.assertEqual(project.shared.fetch('test'), 1)
@@ -112,7 +112,7 @@ class TestExposed(scaffolds.ResultsTest):
         ]))
 
         support.run_command('run')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         self.assertEqual(project.shared.fetch('test'), 1)
@@ -135,7 +135,7 @@ class TestExposed(scaffolds.ResultsTest):
         support.add_step(self, contents=contents)
 
         support.run_command('run')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         self.assertEqual(project.shared.fetch('test'), 1)
@@ -179,4 +179,4 @@ class TestExposed(scaffolds.ResultsTest):
         internal_project.return_value = None
         result = project.get_internal_project()
         self.assertIsNone(result)
-        self.assertEqual(9, sleep.call_count)
+        self.assertEqual(15, sleep.call_count)

--- a/cauldron/test/projects/test_refresh.py
+++ b/cauldron/test/projects/test_refresh.py
@@ -15,7 +15,11 @@ class TestRefresh(scaffolds.ResultsTest):
         Reads the project's data file from disk
         """
 
-        target_project = project if project else cd.project.internal_project
+        target_project = (
+            project
+            if project else
+            cd.project.get_internal_project()
+        )
 
         with open(target_project.source_path, 'r') as f:
             return json.load(f)
@@ -25,8 +29,11 @@ class TestRefresh(scaffolds.ResultsTest):
         """
         Overwrites the existing project data file with the specified data
         """
-
-        target_project = project if project else cd.project.internal_project
+        target_project = (
+            project
+            if project else
+            cd.project.get_internal_project()
+        )
 
         with open(target_project.source_path, 'w+') as f:
             json.dump(data, f)
@@ -47,7 +54,7 @@ class TestRefresh(scaffolds.ResultsTest):
         project_data['steps'].append(step_name)
         self.write_project_file(project_data)
 
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         self.assertTrue(project.refresh(force=True), 'should have refreshed')
         self.assertEqual(len(project.steps), 1)
         self.assertEqual(project.steps[0].definition.name, step_name)
@@ -59,7 +66,7 @@ class TestRefresh(scaffolds.ResultsTest):
 
         support.create_project(self, 'lucius')
 
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         project_data = self.read_project_file()
         project_data['path_results'] = project.source_directory
         self.write_project_file(project_data)
@@ -79,7 +86,7 @@ class TestRefresh(scaffolds.ResultsTest):
         project_data['change'] = True
         self.write_project_file(project_data)
 
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         self.assertTrue(project.refresh(force=True), 'should have refreshed')
         self.assertEqual(len(project.steps), 0)
 
@@ -91,5 +98,5 @@ class TestRefresh(scaffolds.ResultsTest):
         project_data = self.read_project_file()
         self.write_project_file(project_data)
 
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         self.assertFalse(project.refresh(), 'should not have refreshed')

--- a/cauldron/test/runner/test_error_display.py
+++ b/cauldron/test/runner/test_error_display.py
@@ -25,7 +25,7 @@ class TestPrinting(scaffolds.ResultsTest):
             Message('should have failed', response=response)
         )
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         self.assertTrue(
             project.steps[0].dom.find('cd-CodeError') > 0,
@@ -61,7 +61,7 @@ class TestPrinting(scaffolds.ResultsTest):
             Message('should have run step', response=response)
         )
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         self.assertTrue(
             project.steps[0].dom.find(error_string) > 0,

--- a/cauldron/test/runner/test_printing.py
+++ b/cauldron/test/runner/test_printing.py
@@ -29,7 +29,7 @@ class TestPrinting(scaffolds.ResultsTest):
         response = commander.execute('run', '-f')
         response.thread.join(2)
 
-        step = cauldron.project.internal_project.steps[0]
+        step = cauldron.project.get_internal_project().steps[0]
         dom = step.dumps()
         self.assertEqual(dom.count('BAT'), 1, 'first check failed')
 
@@ -65,7 +65,7 @@ class TestPrinting(scaffolds.ResultsTest):
             Message('should have run step', response=response)
         )
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         dom = project.steps[0].dom  # type: str
 
         self.assertEqual(
@@ -99,7 +99,7 @@ class TestPrinting(scaffolds.ResultsTest):
             Message('should have run step', response=response)
         )
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         dom = project.steps[0].dom  # type: str
 
         self.assertEqual(
@@ -133,7 +133,7 @@ class TestPrinting(scaffolds.ResultsTest):
             Message('should have run step', response=response)
         )
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         dom = project.steps[0].dom  # type: str
 
         self.assertEqual(
@@ -168,7 +168,7 @@ class TestPrinting(scaffolds.ResultsTest):
             Message('should have run step', response=response)
         )
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
         dom = project.steps[0].dom  # type: str
 
         self.assertEqual(

--- a/cauldron/test/runner/test_runner.py
+++ b/cauldron/test/runner/test_runner.py
@@ -18,7 +18,7 @@ class TestRunner(scaffolds.ResultsTest):
         response = support.run_command('run -f')
         self.assertTrue(response.failed, 'should have failed')
 
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         self.assertTrue(step.dom.find('cd-CodeError') > 0)
@@ -58,7 +58,7 @@ class TestRunner(scaffolds.ResultsTest):
     def test_library(self):
         """ should refresh the local project library with the updated value """
         support.create_project(self, 'jack')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
 
         lib_directory = os.path.join(project.source_directory, 'libs', '_jack')
         os.makedirs(lib_directory)

--- a/cauldron/test/runner/test_runner_markdown_file.py
+++ b/cauldron/test/runner/test_runner_markdown_file.py
@@ -14,7 +14,7 @@ class TestRunnerMarkdownFile(scaffolds.ResultsTest):
         response = support.run_command('run -f')
         self.assertFalse(response.failed, 'should have failed')
 
-        step = cd.project.internal_project.steps[0]
+        step = cd.project.get_internal_project().steps[0]
         self.assertFalse(step.is_dirty())
 
     def test_invalid_markdown(self):

--- a/cauldron/test/runner/test_runner_redirection.py
+++ b/cauldron/test/runner/test_runner_redirection.py
@@ -20,7 +20,7 @@ class TestRunnerRedirection(scaffolds.ResultsTest):
         support.create_project(self, 'percy')
         support.add_step(self)
 
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         redirection.enable(step)
@@ -39,7 +39,7 @@ class TestRunnerRedirection(scaffolds.ResultsTest):
         support.create_project(self, 'tonks')
         support.add_step(self)
 
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         redirection.enable(step)

--- a/cauldron/test/runner/test_runner_source.py
+++ b/cauldron/test/runner/test_runner_source.py
@@ -16,7 +16,7 @@ class TestRunnerSource(scaffolds.ResultsTest):
         support.create_project(self, 'washington')
         support.add_step(self)
 
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         result = source.get_step(project, step.filename)
@@ -28,7 +28,7 @@ class TestRunnerSource(scaffolds.ResultsTest):
         support.create_project(self, 'george')
         support.add_step(self)
 
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         self.assertIsNone(source.get_step(project, 'FICTIONAL-STEP'))
 
     def test_invalid_step_extension(self):
@@ -37,7 +37,7 @@ class TestRunnerSource(scaffolds.ResultsTest):
         support.create_project(self, 'thomas')
         support.add_step(self, 'TEST.fake')
 
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
         result = source._execute_step(project, step)
 
@@ -47,7 +47,7 @@ class TestRunnerSource(scaffolds.ResultsTest):
         """ should fail to run a None step """
 
         support.create_project(self, 'jefferson')
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         result = source.run_step(Response(), project, 'FAKE.STEP')
         self.assertFalse(result)
 
@@ -60,7 +60,7 @@ class TestRunnerSource(scaffolds.ResultsTest):
 
         support.create_project(self, 'john')
         support.add_step(self)
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         result = source.run_step(Response(), project, step)
@@ -75,7 +75,7 @@ class TestRunnerSource(scaffolds.ResultsTest):
 
         support.create_project(self, 'adams')
         support.add_step(self)
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         result = source.run_step(Response(), project, step)
@@ -86,7 +86,7 @@ class TestRunnerSource(scaffolds.ResultsTest):
 
         support.create_project(self, 'quincy')
         support.add_step(self)
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         package = 'cauldron.runner.source._execute_step'
@@ -100,7 +100,7 @@ class TestRunnerSource(scaffolds.ResultsTest):
 
         support.create_project(self, 'madison')
         support.add_step(self)
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
         step.is_muted = True
 
@@ -112,7 +112,7 @@ class TestRunnerSource(scaffolds.ResultsTest):
 
         support.create_project(self, 'james')
         support.add_step(self)
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
 
         with patch('os.path.exists', return_value=False):
@@ -124,7 +124,7 @@ class TestRunnerSource(scaffolds.ResultsTest):
 
         support.create_project(self, 'monroe')
         support.add_step(self)
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         step = project.steps[0]
         step.is_dirty = lambda: False
 

--- a/cauldron/test/session/test_session_display.py
+++ b/cauldron/test/session/test_session_display.py
@@ -107,7 +107,7 @@ class TestSessionDisplay(scaffolds.ResultsTest):
 
         support.create_project(self, 'starbuck')
 
-        project = cauldron.project.internal_project
+        project = cauldron.project.get_internal_project()
 
         jinja_path = os.path.join(
             project.source_directory,

--- a/cauldron/test/session/test_session_reloading.py
+++ b/cauldron/test/session/test_session_reloading.py
@@ -44,7 +44,7 @@ class TestSessionReloading(scaffolds.ResultsTest):
 
         support.create_project(self, 'betty')
         support.add_step(self)
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         project.current_step = project.steps[0]
 
         self.assertFalse(

--- a/cauldron/test/steptesting/test_functional.py
+++ b/cauldron/test/steptesting/test_functional.py
@@ -136,7 +136,7 @@ def test_no_such_step(tester: CauldronTest):
 
 def test_no_such_project(tester: CauldronTest):
     """Should fail if no project exists"""
-    project = cd.project.internal_project
+    project = cd.project.get_internal_project()
     cd.project.load(None)
 
     with pytest.raises(Exception):

--- a/cauldron/test/steptesting/test_steptest.py
+++ b/cauldron/test/steptesting/test_steptest.py
@@ -112,7 +112,7 @@ class TestStepTesting(StepTestCase):
 
     def test_no_such_project(self):
         """Should fail if no project exists"""
-        project = cd.project.internal_project
+        project = cd.project.get_internal_project()
         cd.project.load(None)
 
         with self.assertRaises(Exception):

--- a/cauldron/test/steptesting/test_support.py
+++ b/cauldron/test/steptesting/test_support.py
@@ -3,19 +3,18 @@ from unittest.mock import patch
 
 import pytest
 
+import cauldron
 from cauldron.steptest import support
 
 
 @patch('time.sleep')
 @patch('cauldron.cli.commander.execute')
-@patch('cauldron.project')
 def test_open_project(
-        project: MagicMock,
         execute: MagicMock,
         sleep: MagicMock
 ):
     """Should fail to open project and eventually give up"""
-    project.internal_project = None
+    cauldron.project.unload()
     execute.return_value = MagicMock()
 
     with pytest.raises(RuntimeError):
@@ -24,7 +23,7 @@ def test_open_project(
     assert 1 == execute.call_count, """
         Expected a single execute call to open the project.
         """
-    assert 101 == sleep.call_count, """
+    assert 15 == sleep.call_count, """
         Expected sleep to be called repeatedly until the wait period
         for opening the project times out.
         """

--- a/cauldron/test/support/__init__.py
+++ b/cauldron/test/support/__init__.py
@@ -1,17 +1,16 @@
-from cauldron import cli
-import sys
 import re
-import time
+import sys
 from unittest.mock import patch
 
 import cauldron
+from cauldron import cli
 from cauldron import environ
 from cauldron.cli import commander
+from cauldron.cli import parse
 from cauldron.cli.shell import CauldronShell
 from cauldron.test.support import scaffolds
-from cauldron.test.support.messages import Message
-from cauldron.cli import parse
 from cauldron.test.support import server
+from cauldron.test.support.messages import Message
 
 try:
   import readline
@@ -122,22 +121,19 @@ def create_project(
     if r.thread:
         r.thread.join()
 
-    # Prevent threading race conditions
-    check_count = 0
-    while confirm and r.success and not cauldron.project.internal_project:
-        if check_count > 100:
-            break
-
-        check_count += 1
-        time.sleep(0.25)
+    project = (
+        cauldron.project.get_internal_project(2)
+        if r.success else
+        None
+    )
 
     if confirm:
         tester.assertFalse(r.failed, Message(
             'support.create_project',
-            ['project should have been created'],
+            'project should have been created',
             response=r
         ))
-        tester.assertIsNotNone(cauldron.project.internal_project)
+        tester.assertIsNotNone(project)
 
     return r
 
@@ -146,13 +142,7 @@ def open_project(
         tester: scaffolds.ResultsTest,
         path: str
 ) -> 'environ.Response':
-    """
-
-    :param tester:
-    :param path:
-    :return:
-    """
-
+    """..."""
     r = environ.Response()
     commander.execute('open', '{} --forget'.format(path), r)
     r.thread.join()
@@ -160,8 +150,7 @@ def open_project(
 
 
 def autocomplete(command: str):
-    """ """
-
+    """..."""
     # On Linux/OSX the completer delims are retrieved from the readline module,
     # but the delims are different on Windows. So for testing consistency we
     # supply the Linux/OSX delims explicitly here in place of:


### PR DESCRIPTION
Adds a `project.get_internal_project()` method to the `ExposedProject` class, which attempts to retrieve the `project.internal_project` value multiple times until either it successfully gets the internal project or the timeout is reached. This is useful for cases where the internal project is loaded asynchronously and a join-like behavior is needed to prevent race conditions between assignment and access of the internal project object.