### PR TITLE
Project Opening

### DIFF
--- a/cauldron/cli/commands/close.py
+++ b/cauldron/cli/commands/close.py
@@ -11,7 +11,6 @@ DESCRIPTION = """
 
 def execute_remote(context: cli.CommandContext) -> Response:
     """ """
-
     thread = sync.send_remote_command(
         command=context.name,
         raw_args=context.raw_args,
@@ -26,7 +25,6 @@ def execute_remote(context: cli.CommandContext) -> Response:
 
 def execute(context: cli.CommandContext) -> Response:
     """ """
-
     if runner.close():
         return context.response.notify(
             kind='SUCCESS',

--- a/cauldron/cli/server/routes/execution.py
+++ b/cauldron/cli/server/routes/execution.py
@@ -168,11 +168,7 @@ def execute(async: bool = False):
 @server_runner.APPLICATION.route('/abort', methods=['GET', 'POST'])
 @authorization.gatekeeper
 def abort():
-    """
-
-    :return:
-    """
-
+    """..."""
     uid_list = list(server_runner.active_execution_responses.keys())
 
     while len(uid_list) > 0:
@@ -201,7 +197,7 @@ def abort():
         except Exception:
             pass
 
-    project = cd.project.get_internal_project()
+    project = cd.project.internal_project
 
     if project and project.current_step:
         step = project.current_step

--- a/cauldron/session/exposed.py
+++ b/cauldron/session/exposed.py
@@ -124,7 +124,7 @@ class ExposedProject(object):
 
     def get_internal_project(
             self,
-            timeout: float = 3
+            timeout: float = 1
     ) -> typing.Union['projects.Project', None]:
         """
         Attempts to return the internally loaded project. This function
@@ -136,12 +136,12 @@ class ExposedProject(object):
             Maximum number of seconds to wait before giving up and returning
             None.
         """
-        count = int(timeout / 0.2)
+        count = int(timeout / 0.1)
         for _ in range(count):
             project = self.internal_project
             if project:
                 return project
-            time.sleep(0.2)
+            time.sleep(0.1)
 
         return self.internal_project
 

--- a/cauldron/settings.json
+++ b/cauldron/settings.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.6",
+  "version": "0.3.7",
   "notebookVersion": "v1"
 }

--- a/cauldron/test/projects/test_exposed.py
+++ b/cauldron/test/projects/test_exposed.py
@@ -179,4 +179,4 @@ class TestExposed(scaffolds.ResultsTest):
         internal_project.return_value = None
         result = project.get_internal_project()
         self.assertIsNone(result)
-        self.assertEqual(15, sleep.call_count)
+        self.assertEqual(10, sleep.call_count)

--- a/cauldron/test/steptesting/test_support.py
+++ b/cauldron/test/steptesting/test_support.py
@@ -23,7 +23,7 @@ def test_open_project(
     assert 1 == execute.call_count, """
         Expected a single execute call to open the project.
         """
-    assert 15 == sleep.call_count, """
+    assert 10 == sleep.call_count, """
         Expected sleep to be called repeatedly until the wait period
         for opening the project times out.
         """

--- a/deployment.md
+++ b/deployment.md
@@ -1,0 +1,31 @@
+# Deployment
+
+## 1. Release the package
+
+Mac OS/Linux:
+```bash
+$ rm -rf ./dist
+$ python3 setup.py sdist bdist_wheel
+$ twine upload dist/cauldron*
+$ python3 conda-recipe/conda-builder.py
+```
+
+Windows:
+```
+> rmdir dist /s /q
+> python setup.py sdist bdist_wheel
+> twine upload dist/cauldron*
+> python conda-recipe\conda-builder.py
+```
+
+## 2. Push new container images
+
+```bash
+$ python docker-builder --publish
+```
+
+## 3. Update release information
+
+```bash
+$ python release.py
+```


### PR DESCRIPTION
Make project opening more robust by replacing the `internal_project` getter with the `get_internal_project()` method that has built-in retry with delay in most cases.