### PR TITLE
Write to Console

### DIFF
--- a/cauldron/render/texts.py
+++ b/cauldron/render/texts.py
@@ -239,5 +239,6 @@ def markdown(source: str = None, source_path: str = None, **kwargs) -> dict:
     body = pattern.sub('data-src="\g<url>"', body)
     return dict(
         body=body,
-        library_includes=library_includes
+        library_includes=library_includes,
+        rendered=rendered
     )

--- a/cauldron/session/display/__init__.py
+++ b/cauldron/session/display/__init__.py
@@ -97,7 +97,7 @@ def markdown(source: str = None, source_path: str = None, **kwargs):
 
     r.append_body(result['body'])
     r.stdout_interceptor.write_source(
-        '{}\n'.format(textwrap.dedent(source))
+        '{}\n'.format(textwrap.dedent(result['rendered']))
     )
 
 

--- a/cauldron/session/exposed.py
+++ b/cauldron/session/exposed.py
@@ -236,6 +236,18 @@ class ExposedStep(object):
         if self._step:
             threads.abort_thread()
 
+    def write_to_console(self, message: str):
+        """
+        Writes the specified message to the console stdout without including
+        it in the notebook display.
+        """
+        if not self._step:
+            raise ValueError(
+                'Cannot write to the console stdout on an uninitialized step'
+            )
+        interceptor = self._step.report.stdout_interceptor
+        interceptor.write_source('{}'.format(message))
+
 
 def render_stop_display(step: 'projects.ProjectStep', message: str):
     """Renders a stop action to the Cauldron display."""

--- a/cauldron/settings.json
+++ b/cauldron/settings.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.7",
+  "version": "0.3.8",
   "notebookVersion": "v1"
 }

--- a/cauldron/steptest/__init__.py
+++ b/cauldron/steptest/__init__.py
@@ -9,6 +9,7 @@ from cauldron.cli import commander
 from cauldron.session import exposed  # noqa
 from cauldron.steptest import support
 from cauldron.steptest.functional import CauldronTest
+from cauldron.steptest.functional import create_test_fixture
 from cauldron.steptest.results import StepTestRunResult
 from cauldron.steptest.support import find_project_directory
 

--- a/cauldron/steptest/functional.py
+++ b/cauldron/steptest/functional.py
@@ -9,6 +9,37 @@ from cauldron.session import exposed  # noqa
 from cauldron.steptest import support
 from cauldron.steptest.results import StepTestRunResult
 
+try:
+    import pytest
+except ImportError:  # pragma: no cover
+    pytest = None
+
+# @pytest.fixture(name='tester')
+# def tester_fixture() -> CauldronTest:
+#     """Create the Cauldron project test environment"""
+#     tester = CauldronTest(project_path=os.path.dirname(__file__))
+#     tester.setup()
+#     yield tester
+#     tester.tear_down()
+
+
+def create_test_fixture(test_file_path: str, fixture_name: str = 'tester'):
+    """..."""
+    path = os.path.realpath(
+        os.path.dirname(test_file_path)
+        if os.path.isfile(test_file_path) else
+        test_file_path
+    )
+
+    @pytest.fixture(name=fixture_name)
+    def tester_fixture() -> CauldronTest:
+        tester = CauldronTest(project_path=path)
+        tester.setup()
+        yield tester
+        tester.tear_down()
+
+    return tester_fixture
+
 
 class CauldronTest:
     """

--- a/cauldron/test/steptesting/test_functional.py
+++ b/cauldron/test/steptesting/test_functional.py
@@ -6,19 +6,11 @@ import pytest
 
 import cauldron as cd
 from cauldron import steptest
-from cauldron.steptest import CauldronTest
+
+tester_fixture = steptest.create_test_fixture(__file__)
 
 
-@pytest.fixture(name='tester')
-def tester_fixture() -> CauldronTest:
-    """Create the Cauldron project test environment"""
-    tester = CauldronTest(project_path=os.path.dirname(__file__))
-    tester.setup()
-    yield tester
-    tester.tear_down()
-
-
-def test_first_step(tester: CauldronTest):
+def test_first_step(tester: steptest.CauldronTest):
     """Should not be any null/NaN values in df"""
     assert cd.shared.fetch('df') is None
     step = tester.run_step('S01-first.py')
@@ -29,7 +21,7 @@ def test_first_step(tester: CauldronTest):
     assert error_echo == ''
 
 
-def test_second_step(tester: CauldronTest):
+def test_second_step(tester: steptest.CauldronTest):
     """
     Should fail without exception because of an exception raised in the
     source but failure is allowed
@@ -41,7 +33,7 @@ def test_second_step(tester: CauldronTest):
     assert 0 < len(error_echo)
 
 
-def test_second_step_strict(tester: CauldronTest):
+def test_second_step_strict(tester: steptest.CauldronTest):
     """
     Should fail because of an exception raised in the source when strict
     failure is enforced
@@ -53,7 +45,7 @@ def test_second_step_strict(tester: CauldronTest):
 @patch('_testlib.patching_test')
 def test_second_step_with_patching(
         patching_test: MagicMock,
-        tester: CauldronTest
+        tester: steptest.CauldronTest
 ):
     """Should override the return value with the patch"""
     patching_test.return_value = 12
@@ -63,14 +55,14 @@ def test_second_step_with_patching(
     assert 12 == cd.shared.result
 
 
-def test_second_step_without_patching(tester: CauldronTest):
+def test_second_step_without_patching(tester: steptest.CauldronTest):
     """Should succeed running the step without patching"""
     cd.shared.value = 42
     tester.run_step('S03-lib-patching.py')
     assert 42 == cd.shared.result
 
 
-def test_to_strings(tester: CauldronTest):
+def test_to_strings(tester: steptest.CauldronTest):
     """Should convert list of integers to a list of strings"""
     before = [1, 2, 3]
     step = tester.run_step('S01-first.py')
@@ -79,7 +71,7 @@ def test_to_strings(tester: CauldronTest):
     assert ['1', '2', '3'] == after
 
 
-def test_modes(tester: CauldronTest):
+def test_modes(tester: steptest.CauldronTest):
     """Should be testing and not interactive or single run"""
     step = tester.run_step('S01-first.py')
     assert step.success
@@ -122,19 +114,19 @@ def test_find_failed_at_root():
         func.assert_called_once_with(subdirectory)
 
 
-def test_make_temp_path(tester: CauldronTest):
+def test_make_temp_path(tester: steptest.CauldronTest):
     """Should make a temp path for testing"""
     temp_path = tester.make_temp_path('some-id', 'a', 'b.test')
     assert temp_path.endswith('b.test')
 
 
-def test_no_such_step(tester: CauldronTest):
+def test_no_such_step(tester: steptest.CauldronTest):
     """Should fail if no such step exists"""
     with pytest.raises(Exception):
         tester.run_step('FAKE-STEP.no-exists')
 
 
-def test_no_such_project(tester: CauldronTest):
+def test_no_such_project(tester: steptest.CauldronTest):
     """Should fail if no project exists"""
     project = cd.project.get_internal_project()
     cd.project.load(None)
@@ -145,7 +137,7 @@ def test_no_such_project(tester: CauldronTest):
     cd.project.load(project)
 
 
-def test_open_project_fails(tester: CauldronTest):
+def test_open_project_fails(tester: steptest.CauldronTest):
     """Should raise Assertion error after failing to open the project"""
     with patch('cauldron.steptest.support.open_project') as open_project:
         open_project.side_effect = RuntimeError('FAKE')

--- a/cauldron/test/writing/test_writing.py
+++ b/cauldron/test/writing/test_writing.py
@@ -7,8 +7,6 @@ class TestWriting(scaffolds.ResultsTest):
 
     def test_plotly_project(self):
         """Should properly write a project that has been run"""
-
         support.open_project(self, '@examples:time-gender')
-
         response = support.run_command('run')
         self.assertFalse(response.failed)

--- a/cauldron/test/writing/test_writing.py
+++ b/cauldron/test/writing/test_writing.py
@@ -1,3 +1,7 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from cauldron.session.writing import file_io
 from cauldron.test import support
 from cauldron.test.support import scaffolds
 
@@ -10,3 +14,51 @@ class TestWriting(scaffolds.ResultsTest):
         support.open_project(self, '@examples:time-gender')
         response = support.run_command('run')
         self.assertFalse(response.failed)
+
+    def test_entry_from_dict_write_entry(self):
+        """Should create a file write entry from the source dict."""
+        result = file_io.entry_from_dict({'contents': 'abc', 'path': '/foo'})
+        self.assertIsInstance(result, file_io.FILE_WRITE_ENTRY)
+        self.assertEqual('abc', result.contents)
+        self.assertEqual('/foo', result.path)
+
+    def test_entry_from_dict_copy_entry(self):
+        """Should create a file copy entry from the source dict."""
+        result = file_io.entry_from_dict({
+            'source': '/bar',
+            'destination': '/foo'
+        })
+        self.assertIsInstance(result, file_io.FILE_COPY_ENTRY)
+        self.assertEqual('/bar', result.source)
+        self.assertEqual('/foo', result.destination)
+
+    @patch('cauldron.session.writing.file_io.copy')
+    @patch('cauldron.session.writing.file_io.write')
+    def test_deploy(self, write: MagicMock, copy: MagicMock):
+        """Should write and copy given entries according to type."""
+        entries = [
+            file_io.FILE_COPY_ENTRY('a', 'b'),
+            file_io.FILE_WRITE_ENTRY('a', 'b'),
+            None
+        ]
+
+        file_io.deploy(entries)
+        self.assertEqual(1, write.call_count)
+        self.assertEqual(entries[1], write.call_args[0][0])
+        self.assertEqual(1, copy.call_count)
+        self.assertEqual(entries[0], copy.call_args[0][0])
+
+    def test_deploy_failed(self):
+        """Should raise value error for invalid/unknown entries."""
+        entries = ['not a valid entry']
+        with self.assertRaises(ValueError):
+            file_io.deploy(entries)
+
+    @patch('time.sleep')
+    @patch('shutil.copy2')
+    def test_copy_retries(self, copy2: MagicMock, sleep: MagicMock):
+        """Should fail to copy entry and raise an IOError."""
+        copy2.side_effect = ValueError('FAKE')
+        with self.assertRaises(IOError):
+            file_io.copy(file_io.FILE_COPY_ENTRY(__file__, '/fake'))
+        self.assertEqual(3, sleep.call_count)


### PR DESCRIPTION
This PR adds a `write_to_console()` function to the `ExposedStep` class that allows for writing message strings to the stdout console without them appearing in the notebook display. From within a notebook it is now possible to call:

`cd.step.write_to_console('my message')`

to write the specified message to the console from within a running step without it appearing in the notebook HTML.

Closes #33 
