### PR TITLE
Markdown Enhancements

### DIFF
--- a/cauldron/render/texts.py
+++ b/cauldron/render/texts.py
@@ -228,7 +228,6 @@ def markdown(source: str = None, source_path: str = None, **kwargs) -> dict:
         <div class="textbox markdown">{{ text }}</div>
         """,
         text=md.markdown(rendered, extensions=[
-            'markdown.extensions.nl2br',
             'markdown.extensions.extra',
             'markdown.extensions.admonition',
             'markdown.extensions.sane_lists'

--- a/cauldron/render/texts.py
+++ b/cauldron/render/texts.py
@@ -153,7 +153,13 @@ def preformatted_text(source: str) -> str:
     )
 
 
-def markdown(source: str = None, source_path: str = None, **kwargs) -> dict:
+def markdown(
+        source: str = None,
+        source_path: str = None,
+        preserve_lines: bool = False,
+        font_size: float = None,
+        **kwargs
+) -> dict:
     """
     Renders a markdown file with support for Jinja2 templating. Any keyword
     arguments will be passed to Jinja2 for templating prior to rendering the
@@ -165,7 +171,15 @@ def markdown(source: str = None, source_path: str = None, **kwargs) -> dict:
     :param source_path:
         The path to a markdown file that should be rendered to HTML for
         notebook display.
-
+    :param preserve_lines:
+        If True, all line breaks will be treated as hard breaks. Use this
+        for pre-formatted markdown text where newlines should be retained
+        during rendering.
+    :param font_size:
+        Specifies a relative font size adjustment. The default value is 1.0,
+        which preserves the inherited font size values. Set it to a value
+        below 1.0 for smaller font-size rendering and greater than 1.0 for
+        larger font size rendering.
     :return:
         The HTML results of rendering the specified markdown string or file.
     """
@@ -223,15 +237,19 @@ def markdown(source: str = None, source_path: str = None, **kwargs) -> dict:
 
         offset = end_index
 
-    body = templating.render(
-        """
-        <div class="textbox markdown">{{ text }}</div>
-        """,
+    extensions = [
+        'markdown.extensions.extra',
+        'markdown.extensions.admonition',
+        'markdown.extensions.sane_lists',
+        'markdown.extensions.nl2br' if preserve_lines else None
+    ]
+
+    body = templating.render_template(
+        'markdown-block.html',
         text=md.markdown(rendered, extensions=[
-            'markdown.extensions.extra',
-            'markdown.extensions.admonition',
-            'markdown.extensions.sane_lists'
-        ])
+            e for e in extensions if e is not None
+        ]),
+        font_size=font_size
     )
 
     pattern = re.compile('src="(?P<url>[^"]+)"')

--- a/cauldron/resources/templates/markdown-block.html
+++ b/cauldron/resources/templates/markdown-block.html
@@ -1,0 +1,6 @@
+<div
+    class="textbox markdown cd-Markdown"
+    style="{{ 'font-size:{}em'.format(font_size) if font_size else '' }}"
+>
+  {{ text }}
+</div>

--- a/cauldron/session/display/__init__.py
+++ b/cauldron/session/display/__init__.py
@@ -73,7 +73,13 @@ def text(value: str, preformatted: bool = False):
     )
 
 
-def markdown(source: str = None, source_path: str = None, **kwargs):
+def markdown(
+        source: str = None,
+        source_path: str = None,
+        preserve_lines: bool = False,
+        font_size: float = None,
+        **kwargs
+):
     """
     Renders the specified source string or source file using markdown and 
     adds the resulting HTML to the notebook display.
@@ -82,6 +88,15 @@ def markdown(source: str = None, source_path: str = None, **kwargs):
         A markdown formatted string.
     :param source_path:
         A file containing markdown text.
+    :param preserve_lines:
+        If True, all line breaks will be treated as hard breaks. Use this
+        for pre-formatted markdown text where newlines should be retained
+        during rendering.
+    :param font_size:
+        Specifies a relative font size adjustment. The default value is 1.0,
+        which preserves the inherited font size values. Set it to a value
+        below 1.0 for smaller font-size rendering and greater than 1.0 for
+        larger font size rendering.
     :param kwargs:
         Any variable replacements to make within the string using Jinja2
         templating syntax.
@@ -91,6 +106,8 @@ def markdown(source: str = None, source_path: str = None, **kwargs):
     result = render_texts.markdown(
         source=source,
         source_path=source_path,
+        preserve_lines=preserve_lines,
+        font_size=font_size,
         **kwargs
     )
     r.library_includes += result['library_includes']

--- a/cauldron/settings.json
+++ b/cauldron/settings.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.8",
+  "version": "0.3.9",
   "notebookVersion": "v1"
 }


### PR DESCRIPTION
A markdown extension was added to attempt to make line breaking handling more explicit but was too aggressive and make every `\n` a line line-break. This removes that extension and restores more natural text flow in markdown rendering.