### PR TITLE
Step Invisibility

### DIFF
--- a/cauldron/resources/templates/step-body.html
+++ b/cauldron/resources/templates/step-body.html
@@ -2,6 +2,7 @@
      id="{{ "project-step" | id }}"
      data-step-name="{{ id }}"
      data-step-updated="{{ last_display_update }}"
+     style="display:{{ 'block' if is_visible else 'none' }}"
 >
   <style scoped>
     .cd-step-elapsed {

--- a/cauldron/runner/source.py
+++ b/cauldron/runner/source.py
@@ -9,10 +9,10 @@ from cauldron.environ import Response
 from cauldron.runner import html_file
 from cauldron.runner import markdown_file
 from cauldron.runner import python_file
+from cauldron.runner import redirection
 from cauldron.session.projects import Project
 from cauldron.session.projects import ProjectStep
 from cauldron.session.projects import StopCondition
-from cauldron.runner import redirection
 
 ERROR_STATUS = 'error'
 OK_STATUS = 'ok'
@@ -29,7 +29,6 @@ def get_step(
     :param step:
     :return:
     """
-
     if isinstance(step, ProjectStep):
         return step
 
@@ -95,7 +94,6 @@ def run_step(
     :param force:
     :return:
     """
-
     step = get_step(project, step)
     if step is None:
         return False
@@ -113,6 +111,7 @@ def run_step(
     project.current_step = step
     step.report.clear()
     step.dom = None
+    step.is_visible = True
     step.is_running = True
     step.progress_message = None
     step.progress = 0

--- a/cauldron/session/exposed.py
+++ b/cauldron/session/exposed.py
@@ -193,6 +193,22 @@ class ExposedStep(object):
         """
         return self._step.elapsed_time
 
+    @property
+    def visible(self) -> bool:
+        """
+        Whether or not this step will be visible in the display after it
+        has finished running. Steps are always visible while running or
+        if they fail to run due to an error. However, if this is set to
+        False, once the step completes successfully it will no longer be
+        visible in the display.
+        """
+        return self._step.is_visible
+
+    @visible.setter
+    def visible(self, value: bool):
+        """Setter for the visible property."""
+        self._step.is_visible = value
+
     def stop(
             self,
             message: str = None,

--- a/cauldron/session/projects/steps.py
+++ b/cauldron/session/projects/steps.py
@@ -31,7 +31,6 @@ class ProjectStep(object):
         :param project:
         :param definition:
         """
-
         self.__class__._reference_index += 1
         self._reference_id = '{}'.format(self.__class__._reference_index)
 
@@ -41,6 +40,7 @@ class ProjectStep(object):
 
         self.last_modified = None
         self.code = None
+        self.is_visible = True
         self.is_running = False
         self._is_dirty = True
         self.error = None
@@ -236,6 +236,10 @@ class ProjectStep(object):
             self.report.flush_stderr()
         ).strip('\n').rstrip()
 
+        # The step will be visible in the display if any of the following
+        # conditions are true.
+        is_visible = self.is_visible or self.is_running or self.error
+
         dom = templating.render_template(
             'step-body.html',
             last_display_update=self.report.last_update_time,
@@ -250,6 +254,7 @@ class ProjectStep(object):
             error=self.error,
             index=self.index,
             is_running=self.is_running,
+            is_visible=is_visible,
             progress_message=self.progress_message,
             progress=int(round(max(0, min(100, 100 * self.progress)))),
             sub_progress_message=self.sub_progress_message,

--- a/cauldron/session/reloading.py
+++ b/cauldron/session/reloading.py
@@ -18,20 +18,17 @@ def get_module(name: str) -> typing.Union[types.ModuleType, None]:
         Either the loaded module with the specified name, or None if no such
         module has been imported.
     """
-
     return sys.modules.get(name)
 
 
 def get_module_name(module: types.ModuleType) -> str:
     """
-    Returns the name of the specified module
+    Returns the name of the specified module by looking up its name in
+    multiple ways to prevent incompatibility issues.
 
     :param module:
-        A module object for which to retrieve the name
-    :return:
-        The name of the module
+        A module object for which to retrieve the name.
     """
-
     try:
         return module.__spec__.name
     except AttributeError:
@@ -52,7 +49,6 @@ def do_reload(module: types.ModuleType, newer_than: int) -> bool:
     :return:
         Whether or not the module was reloaded
     """
-
     path = getattr(module, '__file__')
     directory = getattr(module, '__path__', [None])[0]
 
@@ -84,7 +80,6 @@ def reload_children(parent_module: types.ModuleType, newer_than: int) -> bool:
     :return:
         Whether or not any children were reloaded
     """
-
     if not hasattr(parent_module, '__path__'):
         return False
 

--- a/cauldron/settings.json
+++ b/cauldron/settings.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.9",
+  "version": "0.3.10",
   "notebookVersion": "v1"
 }

--- a/cauldron/test/session/test_session_reloading.py
+++ b/cauldron/test/session/test_session_reloading.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 from email.mime import text as mime_text
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import cauldron as cd
 from cauldron.session import reloading
@@ -9,39 +12,24 @@ from cauldron.test.support.messages import Message
 
 
 class TestSessionReloading(scaffolds.ResultsTest):
-    """ """
-
-    def setUp(self):
-        super(TestSessionReloading, self).setUp()
+    """Test suite for the reloading module"""
 
     def test_watch_bad_argument(self):
-        """
-
-        :return:
-        """
-
+        """Should not reload a module"""
         self.assertFalse(
             reloading.refresh(datetime, force=True),
             Message('Should not reload not a module')
         )
 
     def test_watch_good_argument(self):
-        """
-
-        :return:
-        """
-
+        """Should reload the specified package/subpackage"""
         self.assertTrue(
             reloading.refresh('datetime', force=True),
             Message('Should reload the datetime module')
         )
 
     def test_watch_not_needed(self):
-        """
-
-        :return:
-        """
-
+        """Don't reload modules that haven't changed."""
         support.create_project(self, 'betty')
         support.add_step(self)
         project = cd.project.get_internal_project()
@@ -49,26 +37,76 @@ class TestSessionReloading(scaffolds.ResultsTest):
 
         self.assertFalse(
             reloading.refresh(mime_text),
-            Message('Should not reload if the step has not been run before')
+            Message('Expect no reload if the step has not been run before.')
         )
 
         support.run_command('run')
-
         project.current_step = project.steps[0]
 
         self.assertFalse(
             reloading.refresh(mime_text),
-            Message('Should not reload if module has not changed recently')
+            Message('Expect no reload if module has not changed recently.')
         )
 
     def test_watch_recursive(self):
-        """
-
-        :return:
-        """
-
+        """Should reload the email module."""
         self.assertTrue(
             reloading.refresh('email', recursive=True, force=True),
-            Message('Should reload the email module')
+            Message('Expected email module to be reloaded.')
         )
 
+    def test_get_module_name(self):
+        """Should get the module name from the name of its spec."""
+        target = MagicMock()
+        target.__spec__ = MagicMock()
+        target.__spec__.name = 'hello'
+        self.assertEqual('hello', reloading.get_module_name(target))
+
+    def test_get_module_name_alternate(self):
+        """
+        Should get the module name from its dunder name if the spec name
+        does not exist.
+        """
+        target = Mock(['__name__'])
+        target.__name__ = 'hello'
+        self.assertEqual('hello', reloading.get_module_name(target))
+
+    @patch('cauldron.session.reloading.os.path')
+    @patch('cauldron.session.reloading.importlib.reload')
+    def test_do_reload_error(self, reload: MagicMock, os_path: MagicMock):
+        """Should fail to import the specified module and so return False."""
+        target = MagicMock()
+        target.__file__ = None
+        target.__path__ = ['fake']
+        os_path.getmtime.return_value = 10
+        reload.side_effect = ImportError('FAKE')
+        self.assertFalse(reloading.do_reload(target, 0))
+        self.assertEqual(1, reload.call_count)
+
+    @patch('cauldron.session.reloading.os.path')
+    @patch('cauldron.session.reloading.importlib.reload')
+    def test_do_reload(self, reload: MagicMock, os_path: MagicMock):
+        """Should import the specified module and return True."""
+        target = MagicMock()
+        target.__file__ = 'fake'
+        os_path.getmtime.return_value = 10
+        self.assertTrue(reloading.do_reload(target, 0))
+        self.assertEqual(1, reload.call_count)
+
+    @patch('cauldron.session.reloading.os.path')
+    @patch('cauldron.session.reloading.importlib.reload')
+    def test_do_reload_skip(self, reload: MagicMock, os_path: MagicMock):
+        """
+        Should skip reloading the specified module because it hasn't been
+        modified and return False.
+        """
+        target = MagicMock()
+        target.__file__ = 'fake'
+        os_path.getmtime.return_value = 0
+        self.assertFalse(reloading.do_reload(target, 10))
+        self.assertEqual(0, reload.call_count)
+
+    def test_reload_children_module(self):
+        """Should abort as False for a module that has no children."""
+        target = Mock()
+        reloading.reload_children(target, 10)


### PR DESCRIPTION
Adds support for marking steps as invisible through the `ExposedStep` class using `cd.step.visible = False`. When set to `False`, steps that are not running and have not errored out will be hidden from view in the display.