### PR TITLE
Render to Console

### DIFF
--- a/cauldron/session/exposed.py
+++ b/cauldron/session/exposed.py
@@ -264,6 +264,21 @@ class ExposedStep(object):
         interceptor = self._step.report.stdout_interceptor
         interceptor.write_source('{}'.format(message))
 
+    def render_to_console(self, message: str, **kwargs):
+        """
+        Renders the specified message to the console using Jinja2 template
+        rendering with the kwargs as render variables. The message will also
+        be dedented prior to rendering in the same fashion as other Cauldron
+        template rendering actions.
+
+        :param message:
+            Template string to be rendered.
+        :param kwargs:
+            Variables to be used in rendering the template.
+        """
+        rendered = templating.render(message, **kwargs)
+        return self.write_to_console(rendered)
+
 
 def render_stop_display(step: 'projects.ProjectStep', message: str):
     """Renders a stop action to the Cauldron display."""

--- a/cauldron/test/projects/test_exposed.py
+++ b/cauldron/test/projects/test_exposed.py
@@ -249,6 +249,27 @@ class TestExposed(scaffolds.ResultsTest):
         'cauldron.session.exposed.ExposedStep._step',
         new_callable=PropertyMock
     )
+    def test_render_to_console(self, _step: PropertyMock):
+        """
+        Should render to the console using a write_source function
+        call on the internal step report's stdout_interceptor.
+        """
+        message = '   {{ a }} is not {{ b }}.'
+
+        _step_mock = MagicMock()
+        write_source = MagicMock()
+        _step_mock.report.stdout_interceptor.write_source = write_source
+        _step.return_value = _step_mock
+        step = exposed.ExposedStep()
+        step.render_to_console(message, a=7, b='happy')
+
+        args, kwargs = write_source.call_args
+        self.assertEqual('7 is not happy.', args[0])
+
+    @patch(
+        'cauldron.session.exposed.ExposedStep._step',
+        new_callable=PropertyMock
+    )
     def test_write_to_console_fail(self, _step: PropertyMock):
         """
         Should raise a ValueError when there is no current step to operate


### PR DESCRIPTION
Closes #35

# Description

Adds a new method `ExposedStep.render_to_console()` for rendering messages with Jinja2 before displaying them in the console. The function is similar to the existing `ExposedStep.write_to_console()` method but with support for Jinja2 rendering.

# Steps to Test or Reproduce

```python
import cauldron as cd

cd.step.render_to_console(
     '{{ a }} is not {{ b }}',
    a='happy',
    b='sad'
)
```

# Impacted Areas in Application
- Console output
- Step authoring
