### PR TITLE
Whitespace Annotations

### DIFF
--- a/cauldron/session/display/__init__.py
+++ b/cauldron/session/display/__init__.py
@@ -268,7 +268,7 @@ def whitespace(lines: float = 1.0):
     """
     r = _get_report()
     r.append_body(render.whitespace(lines))
-    r.stdout_interceptor.write_source('[ADDED] Whitespace\n')
+    r.stdout_interceptor.write_source('\n')
 
 
 def html(dom: str):


### PR DESCRIPTION
# Description
Remove the whitespace console annotation, which can be confusing because it's called by the embedded step code in addition to manual invocation.

Closes #45

# Impacted Areas in Application
- Command line output
