### PR TITLE
Reload Control

### DIFF
--- a/cauldron/__init__.py
+++ b/cauldron/__init__.py
@@ -63,6 +63,7 @@ def run_project(
         output_directory: str = None,
         logging_path: str = None,
         reader_path: str = None,
+        reload_project_libraries: bool = False,
         **kwargs
 ) -> ExecutionResult:
     """
@@ -86,6 +87,10 @@ def run_project(
         has finished running. If no path is specified, no reader file will be
         saved. If the path is a directory, a reader file will be saved in that
         directory with the project name as the file name.
+    :param reload_project_libraries:
+        Whether or not to reload all project libraries prior to execution of
+        the project. By default this is False, but can be enabled in cases
+        where refreshing the project libraries before execution is needed.
     :param kwargs:
         Any variables to be available in the cauldron.shared object during
         execution of the project can be specified here as keyword arguments.
@@ -99,5 +104,6 @@ def run_project(
         output_directory=output_directory,
         log_path=logging_path,
         reader_path=reader_path,
+        reload_project_libraries=reload_project_libraries,
         shared_data=kwargs
     )

--- a/cauldron/cli/batcher.py
+++ b/cauldron/cli/batcher.py
@@ -45,7 +45,8 @@ def run_project(
         output_directory: str = None,
         log_path: str = None,
         shared_data: dict = None,
-        reader_path: str = None
+        reader_path: str = None,
+        reload_project_libraries: bool = False
 ) -> ExecutionResult:
     """
     Opens, executes and closes a Cauldron project in a single command in
@@ -66,6 +67,10 @@ def run_project(
         has finished running. If no path is specified, no reader file will be
         saved. If the path is a directory, a reader file will be saved in that
         directory with the project name as the file name.
+    :param reload_project_libraries:
+        Whether or not to reload all project libraries prior to execution of
+        the project. By default this is False, but can be enabled in cases
+        where refreshing the project libraries before execution is needed.
     :return:
         The response result from the project execution
     """
@@ -104,7 +109,8 @@ def run_project(
 
     commander.preload()
     run_response = run_command.execute(
-        context=cli.make_command_context(run_command.NAME)
+        context=cli.make_command_context(run_command.NAME),
+        skip_library_reload=not reload_project_libraries
     )
 
     project_cache = SharedCache().put(

--- a/cauldron/cli/commands/run/__init__.py
+++ b/cauldron/cli/commands/run/__init__.py
@@ -59,6 +59,18 @@ def populate(
     )
 
     parser.add_argument(
+        '--skip-reload',
+        dest='skip_library_reload',
+        default=False,
+        action='store_true',
+        help=cli.reformat("""
+            Whether or not to skip reloading all project libraries prior to
+            execution of the project. By default this is False in which case 
+            the project libraries are reloaded prior to execution.
+            """)
+    )
+
+    parser.add_argument(
         '-c', '--continue',
         dest='continue_after',
         default=False,
@@ -139,7 +151,8 @@ def execute(
         continue_after: bool = False,
         single_step: bool = False,
         limit: int = -1,
-        print_status: bool = False
+        print_status: bool = False,
+        skip_library_reload: bool = False
 ) -> Response:
     """
 
@@ -150,9 +163,12 @@ def execute(
     :param single_step:
     :param limit:
     :param print_status:
+    :param skip_library_reload:
+        Whether or not to skip reloading all project libraries prior to
+        execution of the project. By default this is False in which case
+        the project libraries are reloaded prior to execution.
     :return:
     """
-
     project = run_actions.get_project(context.response)
     if not project:
         return context.response.fail(
@@ -205,7 +221,8 @@ def execute(
         continue_after=continue_after,
         single_step=single_step,
         limit=limit,
-        print_status=print_status
+        print_status=print_status,
+        skip_library_reload=skip_library_reload
     )
 
 
@@ -217,7 +234,8 @@ def run_local(
         continue_after: bool,
         single_step: bool,
         limit: int,
-        print_status: bool
+        print_status: bool,
+        skip_library_reload: bool = False
 ) -> environ.Response:
     """
     Execute the run command locally within this cauldron environment
@@ -230,10 +248,17 @@ def run_local(
     :param single_step:
     :param limit:
     :param print_status:
+    :param skip_library_reload:
+        Whether or not to skip reloading all project libraries prior to
+        execution of the project. By default this is False in which case
+        the project libraries are reloaded prior to execution.
     :return:
     """
-
-    if not environ.modes.has(environ.modes.TESTING):
+    skip_reload = (
+        skip_library_reload
+        or environ.modes.has(environ.modes.TESTING)
+    )
+    if not skip_reload:
         runner.reload_libraries()
 
     environ.log_header('RUNNING', 5)
@@ -314,7 +339,7 @@ def autocomplete(segment: str, line: str, parts: typing.List[str]):
             segment=segment,
             value=parts[-1],
             shorts=['f', 'c', 's', 'l'],
-            longs=['force', 'continue', 'step', 'limit']
+            longs=['force', 'continue', 'step', 'limit', 'skip-reload']
         )
 
     value = parts[-1]

--- a/cauldron/cli/server/run.py
+++ b/cauldron/cli/server/run.py
@@ -1,15 +1,14 @@
 import logging
 import os
 import site
-import sys
+import typing
 from argparse import ArgumentParser
 
 import cauldron as cd
-from cauldron.session import writing
 from cauldron import environ
 from cauldron.render.encoding import ComplexFlaskJsonEncoder
+from cauldron.session import writing
 from flask import Flask
-import typing
 
 APPLICATION = Flask('Cauldron')
 APPLICATION.json_encoder = ComplexFlaskJsonEncoder
@@ -18,7 +17,7 @@ SERVER_VERSION = [0, 0, 1, 1]
 
 try:
     site_packages = list(site.getsitepackages())
-except Exception:
+except Exception:  # pragma: no cover
     site_packages = []
 
 active_execution_responses = dict()  # type: typing.Dict[str, environ.Response]

--- a/cauldron/settings.json
+++ b/cauldron/settings.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.4.0",
+  "version": "0.4.1",
   "notebookVersion": "v1"
 }

--- a/cauldron/test/cli/test_batcher.py
+++ b/cauldron/test/cli/test_batcher.py
@@ -101,16 +101,18 @@ class TestBatcher(scaffolds.ResultsTest):
         run_result = run_project('@examples:hello_cauldron', directory)
         self.assertFalse(run_result.result.success)
 
+    @patch('cauldron.project.get_internal_project')
     @patch('cauldron.cli.batcher.open_command.execute')
     @patch('cauldron.cli.batcher.run_command.execute')
     @patch('cauldron.cli.batcher.save_command.execute')
     @patch('cauldron.cli.batcher.close_command.execute')
     def test_close_fail(
             self,
-            execute_open: MagicMock,
-            execute_run: MagicMock,
+            execute_close: MagicMock,
             execute_save: MagicMock,
-            execute_close: MagicMock
+            execute_run: MagicMock,
+            execute_open: MagicMock,
+            *args
     ):
         """Should fail to close project."""
         successful = MagicMock()


### PR DESCRIPTION
# Description
Allows `cd.run_project` to control whether or not project libraries are reloaded via function argument assignment.

# Impacted Areas in Application
Single run non-interactive execution of projects.

