### PR TITLE
Image Display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ python:
 #  - "3.7"
 #  - "3.7-dev"  # 3.7 development branch
 
-# command to install dependencies
 install:
   - pip install -r requirements.txt
-  - pip install pytest pytest-cov
+  - pip install pytest==4.2.1 pytest-cov
   - pip install codecov
   - pip install coveralls
   - pip install codacy-coverage

--- a/cauldron/render/__init__.py
+++ b/cauldron/render/__init__.py
@@ -226,6 +226,23 @@ def header(contents: str, level: int = 1, expand_full: bool = False) -> str:
     )
 
 
+def image(
+        rendered_path: str,
+        width: int = None,
+        height: int = None,
+        justify: str = None
+) -> str:
+    """Renders an image block"""
+    environ.abort_thread()
+    return templating.render_template(
+        'image.html',
+        path=rendered_path,
+        width=width,
+        height=height,
+        justification=(justify or 'left').lower()
+    )
+
+
 def json(**kwargs) -> str:
     """
 

--- a/cauldron/resources/templates/image.html
+++ b/cauldron/resources/templates/image.html
@@ -1,0 +1,33 @@
+<style data-style="{{ "css" | id }}">
+  #{{ "image-box" | id }}.cd-image-box--left {
+    margin: 10px 20px;
+    text-align: left;
+  }
+
+  #{{ "image-box" | id }}.cd-image-box--center {
+    margin: 10px auto;
+    text-align: center;
+  }
+
+  #{{ "image-box" | id }}.cd-image-box--right {
+    margin: 10px 20px;
+    text-align: right;
+  }
+</style>
+
+<div
+  id="{{ "image-box" | id }}"
+  class="cd-image-box cd-image-box--{{ justification }}"
+>
+  <img
+    id="{{ "image" | id }}"
+    class="cd-image"
+    src="{{ path }}?no-cache={{ "no-cache" | id }}"
+    {% if width is not none %}
+    width="{{ width }}px"
+    {%  endif %}
+    {%  if height is not none %}
+    height="{{ height }}px"
+    {% endif %}
+  />
+</div>

--- a/cauldron/session/display/__init__.py
+++ b/cauldron/session/display/__init__.py
@@ -2,6 +2,7 @@ import json as _json_io
 import textwrap
 import typing
 from datetime import timedelta
+import os as _os
 
 import cauldron as _cd
 from cauldron import environ
@@ -269,6 +270,32 @@ def whitespace(lines: float = 1.0):
     r = _get_report()
     r.append_body(render.whitespace(lines))
     r.stdout_interceptor.write_source('\n')
+
+
+def image(
+        filename: str,
+        width: int = None,
+        height: int = None,
+        justify: str = 'left'
+):
+    """
+    Adds an image to the display. The image must be located within the
+    assets directory of the Cauldron notebook's folder.
+
+    :param filename:
+        Name of the file within the assets directory,
+    :param width:
+        Optional width in pixels for the image.
+    :param height:
+        Optional height in pixels for the image.
+    :param justify:
+        One of 'left', 'center' or 'right', which specifies how the image
+        is horizontally justified within the notebook display.
+    """
+    r = _get_report()
+    path = '/'.join(['reports', r.project.uuid, 'latest', 'assets', filename])
+    r.append_body(render.image(path, width, height, justify))
+    r.stdout_interceptor.write_source('[ADDED] Image\n')
 
 
 def html(dom: str):

--- a/cauldron/settings.json
+++ b/cauldron/settings.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.4.5",
+  "version": "0.4.6",
   "notebookVersion": "v1"
 }

--- a/cauldron/test/render/test_render.py
+++ b/cauldron/test/render/test_render.py
@@ -184,3 +184,17 @@ class TestRender(scaffolds.ResultsTest):
         self.assertGreater(result.find('01'), 0)
         self.assertGreater(result.find('02'), 0)
         self.assertGreater(result.find('12'), 0)
+
+    def test_image(self):
+        """Should render an image dom."""
+        path = 'results/foo/latest/assets/test.jpg'
+        result = render.image(
+            rendered_path=path,
+            width=12,
+            height=13,
+            justify='right'
+        )
+        self.assertTrue('width="12px"' in result)
+        self.assertTrue('height="13px"' in result)
+        self.assertTrue('--right' in result)
+        self.assertTrue('src="{}'.format(path) in result)

--- a/cauldron/test/session/test_session_display.py
+++ b/cauldron/test/session/test_session_display.py
@@ -139,3 +139,14 @@ class TestSessionDisplay(scaffolds.ResultsTest):
         support.add_step(self, contents=step_contents)
         r = support.run_command('run')
         self.assertFalse(r.failed, 'should not have failed')
+
+    def test_image(self):
+        """Should render an assets image to the dom."""
+        support.create_project(self, 'test_image')
+        step_contents = '\n'.join([
+            'import cauldron as cd',
+            'cd.display.image("foo.jpg", 12, 13, "center")'
+        ])
+        support.add_step(self, contents=step_contents)
+        r = support.run_command('run')
+        self.assertTrue(r.success, 'should not have failed')


### PR DESCRIPTION
# Description
Adds `cd.display.image()` that will include an image from
within the project's assets directory in the notebook
display.

# Impacted Areas in Application
Cauldron notebook display