### PR TITLE
Library Directories

### DIFF
--- a/cauldron/cli/commands/open/__init__.py
+++ b/cauldron/cli/commands/open/__init__.py
@@ -1,7 +1,6 @@
 import os
 import typing
 from argparse import ArgumentParser
-import requests
 
 import cauldron
 from cauldron import cli

--- a/cauldron/cli/commands/open/opener.py
+++ b/cauldron/cli/commands/open/opener.py
@@ -171,7 +171,10 @@ def open_project(
             message='Unable to write project notebook data'
         ).console(whitespace=1).response
 
-    runner.add_library_path(project.source_directory)
+    # Should no longer be needed because the source directory is included
+    # in the library directories as of v0.4.7
+    # runner.add_library_path(project.source_directory)
+    runner.reload_libraries(project.library_directories)
 
     return response.update(
         project=project.kernel_serialize()

--- a/cauldron/cli/sync/files.py
+++ b/cauldron/cli/sync/files.py
@@ -159,7 +159,13 @@ def send_all_in(
         directory
     ).rstrip(os.path.sep)
 
-    for file_path in glob.iglob(glob_path, recursive=True):
+    # Only send files that have non-zero size
+    file_paths = (
+        p
+        for p in glob.iglob(glob_path, recursive=True)
+        if os.path.isfile(p) and os.path.getsize(p) > 0
+    )
+    for file_path in file_paths:
         relative_path = file_path[len(root_path):].lstrip(os.path.sep)
 
         response = send(

--- a/cauldron/session/projects/project.py
+++ b/cauldron/session/projects/project.py
@@ -51,11 +51,9 @@ class Project:
         self.remote_source_directory = None  # type: str
 
         def as_shared_cache(source):
-            if source is None:
-                return SharedCache()
-            if not hasattr(source, 'fetch'):
+            if source and not hasattr(source, 'fetch'):
                 return SharedCache().put(**source)
-            return source
+            return source or SharedCache()
 
         self.stop_condition = StopCondition(False, False)  # type: StopCondition
         self.shared = as_shared_cache(shared)
@@ -99,6 +97,9 @@ class Project:
 
         # Include the remote shared library folder as well
         folders.append('../__cauldron_shared_libs')
+
+        # Include the project directory as well
+        folders.append(self.source_directory)
 
         return [
             environ.paths.clean(os.path.join(self.source_directory, folder))

--- a/cauldron/settings.json
+++ b/cauldron/settings.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.4.6",
+  "version": "0.4.7",
   "notebookVersion": "v1"
 }

--- a/cauldron/test/cli/server/routes/synchronize/test_status.py
+++ b/cauldron/test/cli/server/routes/synchronize/test_status.py
@@ -44,5 +44,5 @@ class TestStatus(scaffolds.ResultsTest):
         project = cauldron.project.get_internal_project()
         results = status.of_project(project)
 
-        self.assertEqual(len(results['libraries']), 2)
+        self.assertEqual(len(results['libraries']), 3)
         self.assertEqual(len(results['project'].keys()), 1)


### PR DESCRIPTION
# Description
Improve the management of library directories during project opening
and include the project directory itself within the directories where
library files might exist.

# Steps to Test or Reproduce
Run a notebook with libraries in non-interactive mode. Those libraries are not properly managed in the Python path over the lifecycle of the non-interactive run and can cause import errors.

# Impacted Areas in Application
Library management in non-interactive runs.

Closes #59 