### PR TITLE
Step Testing Enhancements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,4 @@
 include LICENSE
 include README.rst
 include cauldron/settings.json
-recursive-include cauldron/resources/web *
-recursive-include cauldron/resources/examples *
-recursive-include cauldron/resources/templates *
+recursive-include cauldron/resources *

--- a/cauldron/settings.json
+++ b/cauldron/settings.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "notebookVersion": "v1"
 }

--- a/cauldron/steptest/results.py
+++ b/cauldron/steptest/results.py
@@ -5,7 +5,8 @@ from cauldron.session.caching import SharedCache
 
 class StepTestRunResult:
     """
-    This class contains information returned from running a step during testing.
+    This class contains information returned from running a step
+    during testing.
     """
 
     def __init__(
@@ -23,7 +24,6 @@ class StepTestRunResult:
         Container object that holds all of the local variables that were
         defined within the run step
         """
-
         return self._locals
 
     @property
@@ -33,8 +33,14 @@ class StepTestRunResult:
         False if there as an uncaught exception during the execution of the
         step.
         """
-
         return not self._response.failed
+
+    @property
+    def step(self) -> 'projects.ProjectStep':
+        """
+        The internal step object for the step that was executed.
+        """
+        return self._step
 
     def echo_error(self) -> str:
         """
@@ -45,7 +51,6 @@ class StepTestRunResult:
             The string representation of the exception that caused the running
             step to fail or a blank string if no exception occurred
         """
-
         if not self._response.errors:
             return ''
 

--- a/cauldron/test/steptesting/test_functional.py
+++ b/cauldron/test/steptesting/test_functional.py
@@ -72,12 +72,18 @@ def test_to_strings(tester: steptest.CauldronTest):
 
 
 def test_modes(tester: steptest.CauldronTest):
-    """Should be testing and not interactive or single run"""
+    """Should be testing and not interactive or single run."""
     step = tester.run_step('S01-first.py')
     assert step.success
     assert step.local.is_testing
     assert not step.local.is_interactive
     assert not step.local.is_single_run
+
+
+def test_partial_match(tester: steptest.CauldronTest):
+    """Should run S01 from a partial step name."""
+    result = tester.run_step('first')
+    assert result.step.definition.name == 'S01-first.py'
 
 
 def test_find_in_current_path():

--- a/cauldron/test/steptesting/test_support.py
+++ b/cauldron/test/steptesting/test_support.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from pytest import mark
 
 import cauldron
 from cauldron.steptest import support
@@ -27,3 +28,41 @@ def test_open_project(
         Expected sleep to be called repeatedly until the wait period
         for opening the project times out.
         """
+
+
+MOCK_STEP_NAMES = [
+    'S01-Foo.py',
+    'S02-Bar.py',
+    'S03-FooBar.py',
+    'S04-Spam.py',
+]
+
+FIND_SCENARIOS = (
+    ('S03-FooBar.py', MOCK_STEP_NAMES[2]),
+    ('S04-Spam.py', MOCK_STEP_NAMES[3]),
+    ('S04-Spam', MOCK_STEP_NAMES[3]),
+    ('Spam', MOCK_STEP_NAMES[3]),
+    ('Foo', MOCK_STEP_NAMES[0]),
+    ('S05', None),
+)
+
+
+@mark.parametrize('lookup, expected', FIND_SCENARIOS)
+def test_find_matching_step(lookup: str, expected: str):
+    """Should find the expected matching step for the given scenario."""
+    steps = []
+    for name in MOCK_STEP_NAMES:
+        step = MagicMock()
+        step.name = name
+        step.definition.name = name
+        steps.append(step)
+
+    project = MagicMock(steps=steps)
+
+    observed = support.find_matching_step(project, lookup)
+    if expected is None:
+        assert observed is None, 'Expect no step match.'
+    else:
+        assert observed.definition.name == expected, """
+            Expect the lookup "{lookup}" to match the step name "{expected}".
+            """.format(lookup=lookup, expected=expected)

--- a/deployment.md
+++ b/deployment.md
@@ -19,7 +19,9 @@ $ python3 conda-recipe/conda-builder.py
 
 WINDOWS:
 ```powershell
-> rmdir dist /s /q
+CMD> rmdir dist /s /q
+PS> rm dist -r -fo
+
 > python setup.py sdist bdist_wheel
 > twine upload dist/cauldron*
 > docker run --rm -it -v ${pwd}:/cauldron continuumio/anaconda3 /bin/bash

--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,7 @@ def populate_extra_files():
     """
     out = ['cauldron/settings.json']
 
-    for entry in glob.iglob('cauldron/resources/examples/**/*', recursive=True):
-        out.append(entry)
-
-    for entry in glob.iglob('cauldron/resources/templates/**/*', recursive=True):
-        out.append(entry)
-
-    for entry in glob.iglob('cauldron/resources/web/**/*', recursive=True):
+    for entry in glob.iglob('cauldron/resources/**/*', recursive=True):
         out.append(entry)
 
     return out


### PR DESCRIPTION
This PR improves step testing by allowing the `run_step` method on the
StepTest class-based and function test objects to accept partial step
names. This allows a bit more flexibility in defining the step being
run and reduces the refactoring when steps are renamed. For example,
it is now possible for `run_step('foo')` to work in a project with
a step named `S05-foo.py`. The prefix and suffix can be ignored
when specifying the step. Although partial matching can lead to issues
if names are not distinct within a project.
