### PR TITLE
Python Compatibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,18 @@ stages:
   - check
   - broadcast
 
+pytest-py353:
+  image: python:3.5.3
+  stage: check
+  script:
+    - export PYTHONPATH="${PYTHONPATH}:$(pwd)"
+    - pip install -r requirements.txt
+    - >
+      py.test
+      --cov-report term
+      --cov=cauldron
+      .
+
 pytest-py35:
   image: python:3.5
   stage: check

--- a/cauldron/cli/commands/listing/__init__.py
+++ b/cauldron/cli/commands/listing/__init__.py
@@ -20,7 +20,7 @@ def populate(
         parser: ArgumentParser,
         raw_args: typing.List[str],
         assigned_args: dict
-) -> typing.NoReturn:
+):
     """
     Populates the commend execution argument parser with the arguments
     for the command.

--- a/cauldron/settings.json
+++ b/cauldron/settings.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "notebookVersion": "v1"
 }

--- a/docker-builder.py
+++ b/docker-builder.py
@@ -15,22 +15,22 @@ BUILDS = [
         'build_args': {'PARENT': 'python:3.6', 'TYPE': 'ui'},
     },
     {
-        'ids': [
-            'standard', 'kernel-standard',
-            'standard37', 'kernel-standard37'
-        ],
+        'ids': ['standard37', 'kernel-standard37'],
         'build_args': {'PARENT': 'python:3.7', 'TYPE': 'kernel'},
     },
     {
-        'ids': ['ui-standard', 'ui-standard37'],
+        'ids': ['ui-standard37'],
         'build_args': {'PARENT': 'python:3.7', 'TYPE': 'ui'},
     },
     {
-        'ids': ['standard38', 'kernel-standard38'],
+        'ids': [
+            'standard', 'kernel-standard',
+            'standard38', 'kernel-standard38'
+        ],
         'build_args': {'PARENT': 'python:3.8', 'TYPE': 'kernel'},
     },
     {
-        'ids': ['ui-standard38'],
+        'ids': ['ui-standard', 'ui-standard38'],
         'build_args': {'PARENT': 'python:3.8', 'TYPE': 'ui'},
     },
     {


### PR DESCRIPTION
This restores compatibility with Python 3.5.3 and adds a CI stage to
test against that version as the latest version of 3.5 has functionality
that did not exist in the earlier version.